### PR TITLE
Scale EPAD output energy to unity

### DIFF
--- a/framework/modules/saf_hoa/saf_hoa_internal.c
+++ b/framework/modules/saf_hoa/saf_hoa_internal.c
@@ -87,6 +87,8 @@ void getEPAD
 
     /* Apply normalisation, and scale by number of loudspeakers */
     scale = sqrtf(4.0f*SAF_PI/(float)nLS);
+    /* Scale output max "energy" to unity after truncation */
+    scale *= sqrtf((float)nLS / (float)nSH);
     utility_svsmul(decMtx, &scale, nLS*nSH, decMtx);
 
     /* clean-up */


### PR DESCRIPTION
Scale EPAD max energy to unity.
Separate line for clarity, cancels out with previous line.
Not (explicitly) mentioned in the original paper, but useful to avoid (order dependent) level jumps.