### PR TITLE
Allow external definition of example_list

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,8 +1,10 @@
 
 message(STATUS "Configuring SAF examples:")
 
+if(NOT DEFINED saf_example_list)
+
 # List of examples which have the common structure (<example>.h/.c, <example>_internal.h/.c) and do not require the saf_sofa_reader module:
-set(example_list
+set(saf_example_list
     ambi_drc
     ambi_enc
     array2sh
@@ -19,7 +21,7 @@ set(example_list
 
 # Append examples which use the saf_sofa_reader module, or print a warning
 if(SAF_ENABLE_SOFA_READER_MODULE)
-set(example_list ${example_list}
+set(saf_example_list ${saf_example_list}
     ambi_bin 
     ambi_dec
     binauraliser)
@@ -27,14 +29,16 @@ else()
     message(STATUS "  Note: examples that depend on the saf_sofa_reader module have been disabled")
 endif()
 
+endif()
+
 # Find number of examples
-list(LENGTH example_list num_examples)
+list(LENGTH saf_example_list num_examples)
 math(EXPR num_examples "${num_examples} - 1")
 
 # Loop over all examples
 foreach(current_example RANGE ${num_examples})
     # Get current example string
-    list(GET example_list ${current_example} current_string)
+    list(GET saf_example_list ${current_example} current_string)
 
     # Set-up project
     message(STATUS "  ${current_string}")


### PR DESCRIPTION
It can be useful to limit the build to only a few examples. The simple solution to this would be to check if the "example_list" variable is set outside examples\CMakeLists.txt.

To avoid duplicate variable names, I've added a saf_ prefix: "saf_example_list".

With this change I can add the following to a CMake file external to SAF:

```
set(SAF_BUILD_EXAMPLES OFF)
add_subdirectory(Spatial_Audio_Framework)

set(example_prefix "saf_")
set(saf_example_list
    ambi_bin
    ambi_enc
    array2sh)
add_subdirectory(Spatial_Audio_Framework/examples)
```