### PR TITLE
Added missing calls to free in array2sh_destroy and getBinDecoder_MAGLS

### DIFF
--- a/examples/src/array2sh/array2sh.c
+++ b/examples/src/array2sh/array2sh.c
@@ -120,6 +120,10 @@ void array2sh_destroy
         free(pData->bN_inv_dB);
         
         free(pData->progressBarText);
+
+        free(pData->bN);
+        free(pData->cSH);
+        free(pData->lSH);
         
         free(pData);
         pData = NULL;

--- a/framework/modules/saf_hoa/saf_hoa_internal.c
+++ b/framework/modules/saf_hoa/saf_hoa_internal.c
@@ -613,6 +613,7 @@ void getBinDecoder_MAGLS
     
     free(W);
     free(Y_na);
+    free(Yna_W);
     free(Yna_W_Yna);
     free(Yna_W_H);
     free(B_magls);


### PR DESCRIPTION
## What is the goal of this PR?

Fix memory leakage in array2sh and saf_hoa

## What are the changes implemented in this PR?

Added missing calls to free that lead to the memory leakage
