### PR TITLE
Extend HRIR pre-processing

### DIFF
--- a/examples/include/ambi_bin.h
+++ b/examples/include/ambi_bin.h
@@ -75,6 +75,14 @@ typedef enum {
 /** Number of decoding method options */
 #define AMBI_BIN_NUM_DECODING_METHODS ( 5 )
 
+typedef enum {
+    PREPROC_OFF = 1,
+    PREPROC_EQ,
+    PREPROC_PHASE,
+    PREPROC_ALL,
+
+}AMBI_BIN_PREPROC;
+
 
 /* ========================================================================== */
 /*                               Main Functions                               */
@@ -219,6 +227,13 @@ void ambi_bin_setEnableDiffuseMatching(void* const hAmbi, int newState);
  * Sets a flag to enable/disable (1 or 0) truncation EQ
  */
 void ambi_bin_setEnableTruncationEQ(void* const hAmbi, int newState);
+
+/**
+ * Sets a flag to enable/disable (1 or 0) diffuse EQ
+ */
+void ambi_bin_setEnableDiffEQ(void* const hAmbi, int newState);
+
+void ambi_bin_setHrirPreProc(void* const hAmbi, AMBI_BIN_PREPROC newType);
 
 /**
  * Sets the flag to enable/disable (1 or 0) sound-field rotation
@@ -367,6 +382,14 @@ int ambi_bin_getEnableDiffuseMatching(void* const hAmbi);
  * enabled ('0' disabled, '1' enabled).
  */
 int ambi_bin_getEnableTruncationEQ(void* const hAmbi);
+
+/**
+ * Returns the flag value which dictates whether the diffuse EQ is currently
+ * enabled ('0' disabled, '1' enabled).
+ */
+int ambi_bin_getEnableDiffEQ(void* const hAmbi);
+
+int ambi_bin_getHrirPreProc(void* const hAmbi);
 
 /**
  * Returns the flag value which dictates whether to enable/disable sound-field

--- a/examples/include/ambi_bin.h
+++ b/examples/include/ambi_bin.h
@@ -76,10 +76,10 @@ typedef enum {
 #define AMBI_BIN_NUM_DECODING_METHODS ( 5 )
 
 typedef enum {
-    PREPROC_OFF = 1,
-    PREPROC_EQ,
-    PREPROC_PHASE,
-    PREPROC_ALL,
+    PREPROC_OFF = 1,        /**< No pre-processing active */
+    PREPROC_EQ,             /**< Diffuse EQ (compensates CTF) */
+    PREPROC_PHASE,          /**< Phase simplification based on ITD */
+    PREPROC_ALL,            /**< All of the above */
 
 }AMBI_BIN_PREPROC;
 
@@ -231,9 +231,13 @@ void ambi_bin_setEnableTruncationEQ(void* const hAmbi, int newState);
 /**
  * Sets a flag to enable/disable (1 or 0) diffuse EQ
  */
-void ambi_bin_setEnableDiffEQ(void* const hAmbi, int newState);
+//void ambi_bin_setEnableDiffEQ(void* const hAmbi, int newState);
 
-void ambi_bin_setHrirPreProc(void* const hAmbi, AMBI_BIN_PREPROC newType);
+/**
+ * Sets HRIR pre-processing strategy.
+ * (see #AMBI_BIN_PREPROC enum)
+ */
+void ambi_bin_setHRIRsPreProc(void* const hAmbi, AMBI_BIN_PREPROC newType);
 
 /**
  * Sets the flag to enable/disable (1 or 0) sound-field rotation
@@ -387,9 +391,13 @@ int ambi_bin_getEnableTruncationEQ(void* const hAmbi);
  * Returns the flag value which dictates whether the diffuse EQ is currently
  * enabled ('0' disabled, '1' enabled).
  */
-int ambi_bin_getEnableDiffEQ(void* const hAmbi);
+// int ambi_bin_getEnableDiffEQ(void* const hAmbi);
 
-int ambi_bin_getHrirPreProc(void* const hAmbi);
+/**
+ * Returns HRIR pre-processing strategy.  
+ * (see #AMBI_BIN_PREPROC enum)
+ */
+int ambi_bin_getHRIRsPreProc(void* const hAmbi);
 
 /**
  * Returns the flag value which dictates whether to enable/disable sound-field

--- a/examples/include/ambi_dec.h
+++ b/examples/include/ambi_dec.h
@@ -225,6 +225,16 @@ void ambi_dec_setLoudspeakerElev_deg(void* const hAmbi,
 void ambi_dec_setNumLoudspeakers(void* const hAmbi, int new_nLoudspeakers);
 
 /**
+ * Sets flag to dictate whether the output loudspeaker signals should be
+ * binauralised
+ *
+ * @param[in] hAmbi    ambi_dec handle
+ * @param[in] newState '0' output loudspeaker signals, '1' output binaural
+ *                     signals
+ */
+void ambi_dec_setBinauraliseLSflag(void* const hAmbi, int newState);
+
+/**
  * Sets flag to dictate whether the default HRIRs in the Spatial_Audio_Framework
  * should be used (1), or a custom HRIR set loaded via a SOFA file (0).
  *
@@ -238,16 +248,6 @@ void ambi_dec_setNumLoudspeakers(void* const hAmbi, int new_nLoudspeakers);
 void ambi_dec_setUseDefaultHRIRsflag(void* const hAmbi, int newState);
 
 /**
- * Sets flag to dictate whether the output loudspeaker signals should be
- * binauralised
- *
- * @param[in] hAmbi    ambi_dec handle
- * @param[in] newState '0' output loudspeaker signals, '1' output binaural
- *                     signals
- */
-void ambi_dec_setBinauraliseLSflag(void* const hAmbi, int newState);
-
-/**
  * Sets the file path for a .sofa file, in order to employ a custom HRIR set for
  * the decoding.
  *
@@ -259,6 +259,11 @@ void ambi_dec_setBinauraliseLSflag(void* const hAmbi, int newState);
  * @param[in] path  File path to .sofa file (WITH file extension)
  */
 void ambi_dec_setSofaFilePath(void* const hAmbi, const char* path);
+
+/**
+ * Enable (1) or disable (0) the pre-processing applied to the HRTFs.
+ */
+void ambi_dec_setEnableHRIRsPreProc(void* const hAmbi, int newState);
 
 /**
  * Sets the source preset (ideal SH or SH signals derived from mic arrays)
@@ -429,6 +434,13 @@ int ambi_dec_getMaxNumLoudspeakers(void);
 int  ambi_dec_getNSHrequired(void* const hAmbi); 
 
 /**
+ * Returns the value of a flag used to dictate whether the loudspeaker signals
+ * should be binauralised (0: output loudspeaker signals, 1: output binaural
+ * signals).
+ */
+int ambi_dec_getBinauraliseLSflag(void* const hAmbi);
+
+/**
  * Returns the value of a flag used to dictate whether the default HRIRs in the
  * Spatial_Audio_Framework should be used (1), or a custom HRIR set loaded via a
  * SOFA file (0).
@@ -439,13 +451,6 @@ int  ambi_dec_getNSHrequired(void* const hAmbi);
 int ambi_dec_getUseDefaultHRIRsflag(void* const hAmbi);
 
 /**
- * Returns the value of a flag used to dictate whether the loudspeaker signals
- * should be binauralised (0: output loudspeaker signals, 1: output binaural
- * signals).
- */
-int ambi_dec_getBinauraliseLSflag(void* const hAmbi);
-
-/**
  * Returns the file path for a .sofa file (WITH file extension)
  *
  * @note If the custom set failes to load correctly, ambi_dec will revert to the
@@ -453,6 +458,12 @@ int ambi_dec_getBinauraliseLSflag(void* const hAmbi);
  *       was successful.
  */
 char* ambi_dec_getSofaFilePath(void* const hAmbi);
+
+/**
+ * Returns the flag indicating whether the pre-processing applied to the HRTFs
+ * is enabled (1) or disabled (0)
+ */
+int ambi_dec_getEnableHRIRsPreProc(void* const hAmbi);
 
 /**
  * Returns the Ambisonic channel ordering convention currently being used to

--- a/examples/include/binauraliser.h
+++ b/examples/include/binauraliser.h
@@ -167,6 +167,11 @@ void binauraliser_setUseDefaultHRIRsflag(void* const hBin, int newState);
 void binauraliser_setSofaFilePath(void* const hBin, const char* path);
 
 /**
+ * Enable (1) or disable (0) the pre-processing applied to the HRTFs
+ */
+void binauraliser_setEnableHRIRsPreProc(void* const hBin, int newState);
+
+/**
  * Loads an input preset (see #SOURCE_CONFIG_PRESETS enum)
  */
 void binauraliser_setInputConfigPreset(void* const hBin, int newPresetID);
@@ -218,10 +223,6 @@ void binauraliser_setRPYflag(void* const hBin, int newState);
 /** NOT IMPLEMENTED YET */
 void binauraliser_setInterpMode(void* const hBin, int newMode);
 
-/**
- * Enable (1) or disable (0) the diffuse-field EQ applied to the HRTFs
- */
-void binauraliser_setEnableHRTFDiffuseEQ(void* const hBin, int newState);
 
 
 /* ========================================================================== */
@@ -333,6 +334,12 @@ int binauraliser_getUseDefaultHRIRsflag(void* const hBin);
 char* binauraliser_getSofaFilePath(void* const hBin);
 
 /**
+ * Returns the flag indicating whether the pre-processing applied to the HRTFs
+ * is enabled (1) or disabled (0)
+ */
+int binauraliser_getEnableHRIRsPreProc(void* const hBin);
+
+/**
  * Returns the DAW/Host sample rate
  */
 int binauraliser_getDAWsamplerate(void* const hBin);
@@ -390,12 +397,6 @@ int binauraliser_getInterpMode(void* const hBin);
  * purposes)
  */
 int binauraliser_getProcessingDelay(void);
-
-/**
- * Returns the flag indicating whether the diffuse-field EQ applied to the HRTFs
- * is enabled (1) or disabled (0)
- */
-int binauraliser_getEnableHRTFDiffuseEQ(void* const hBin);
 
 
 #ifdef __cplusplus

--- a/examples/include/binauraliser.h
+++ b/examples/include/binauraliser.h
@@ -167,7 +167,7 @@ void binauraliser_setUseDefaultHRIRsflag(void* const hBin, int newState);
 void binauraliser_setSofaFilePath(void* const hBin, const char* path);
 
 /**
- * Enable (1) or disable (0) the pre-processing applied to the HRTFs
+ * Enable (1) or disable (0) the pre-processing applied to the HRTFs.
  */
 void binauraliser_setEnableHRIRsPreProc(void* const hBin, int newState);
 
@@ -335,7 +335,7 @@ char* binauraliser_getSofaFilePath(void* const hBin);
 
 /**
  * Returns the flag indicating whether the pre-processing applied to the HRTFs
- * is enabled (1) or disabled (0)
+ * is enabled (1) or disabled (0).
  */
 int binauraliser_getEnableHRIRsPreProc(void* const hBin);
 

--- a/examples/src/ambi_bin/ambi_bin.c
+++ b/examples/src/ambi_bin/ambi_bin.c
@@ -583,16 +583,16 @@ void ambi_bin_setEnableTruncationEQ(void* const hAmbi, int newState)
     }
 }
 
-void ambi_bin_setEnableDiffEQ(void* const hAmbi, int newState)
+/* void ambi_bin_setEnableDiffEQ(void* const hAmbi, int newState)
 {
-/*     ambi_bin_data *pData = (ambi_bin_data*)(hAmbi);
+    ambi_bin_data *pData = (ambi_bin_data*)(hAmbi);
     if(pData->enablePreProcEQ != newState){
         pData->enablePreProcEQ = newState;
         ambi_bin_refreshParams(hAmbi);  // re-init and re-calc
-    } */
-}
+    }
+} */
 
-void ambi_bin_setHrirPreProc(void* const hAmbi, AMBI_BIN_PREPROC newType)
+void ambi_bin_setHRIRsPreProc(void* const hAmbi, AMBI_BIN_PREPROC newType)
 {
     ambi_bin_data *pData = (ambi_bin_data*)(hAmbi);
     if(pData->preProc != newType){
@@ -693,13 +693,13 @@ int ambi_bin_getUseDefaultHRIRsflag(void* const hAmbi)
     return pData->useDefaultHRIRsFLAG;
 }
 
-int ambi_bin_getEnableDiffEQ(void* const hAmbi)
+/* int ambi_bin_getEnableDiffEQ(void* const hAmbi)
 {
-/*     ambi_bin_data *pData = (ambi_bin_data*)(hAmbi);
-    return pData->enablePreProcEQ; */
-}
+    ambi_bin_data *pData = (ambi_bin_data*)(hAmbi);
+    return pData->enablePreProcEQ;
+} */
 
-int ambi_bin_getHrirPreProc(void* const hAmbi)
+int ambi_bin_getHRIRsPreProc(void* const hAmbi)
 {
     ambi_bin_data *pData = (ambi_bin_data*)(hAmbi);
     return pData->preProc;

--- a/examples/src/ambi_bin/ambi_bin.c
+++ b/examples/src/ambi_bin/ambi_bin.c
@@ -253,11 +253,11 @@ void ambi_bin_initCodec
             pars->weights = realloc1d(pars->weights, pars->N_hrir_dirs*sizeof(float));
             getVoronoiWeights(pars->hrir_dirs_deg, pars->N_hrir_dirs, 0, pars->weights);
         }
-        else
+        else{
             pars->weights = malloc1d(pars->N_hrir_dirs*sizeof(float));
             for(int idx=0; idx < pars->N_hrir_dirs; idx++)
                 pars->weights[idx] = 4.f*SAF_PI / (float)pars->N_hrir_dirs;
-
+        }
         /* HRIR pre-processing */
         pData->progressBar0_1 = 0.75f;
         if(pData->preProc != PREPROC_OFF){

--- a/examples/src/ambi_bin/ambi_bin.c
+++ b/examples/src/ambi_bin/ambi_bin.c
@@ -244,25 +244,30 @@ void ambi_bin_initCodec
         estimateITDs(pars->hrirs, pars->N_hrir_dirs, pars->hrir_len, pars->hrir_fs, pars->itds_s);
  
         /* convert hrirs to filterbank coefficients */
-        pData->progressBar0_1 = 0.6f;
+        pData->progressBar0_1 = 0.4f;
         pars->hrtf_fb = realloc1d(pars->hrtf_fb, HYBRID_BANDS * NUM_EARS * (pars->N_hrir_dirs)*sizeof(float_complex));
         HRIRs2HRTFs_afSTFT(pars->hrirs, pars->N_hrir_dirs, pars->hrir_len, HOP_SIZE, 1, pars->hrtf_fb);
-        if(pData->preProc != PREPROC_OFF){
-            if(pData->preProc == PREPROC_EQ)
-                diffuseFieldEqualiseHRTFs(pars->N_hrir_dirs, pars->itds_s, pData->freqVector, HYBRID_BANDS, 1, 0, pars->hrtf_fb);
-            if(pData->preProc == PREPROC_PHASE)
-                diffuseFieldEqualiseHRTFs(pars->N_hrir_dirs, pars->itds_s, pData->freqVector, HYBRID_BANDS, 0, 1, pars->hrtf_fb);
-            if(pData->preProc == PREPROC_ALL)
-                diffuseFieldEqualiseHRTFs(pars->N_hrir_dirs, pars->itds_s, pData->freqVector, HYBRID_BANDS, 1, 1, pars->hrtf_fb);
-        }
         /* get integration weights */
-        pData->progressBar0_1 = 0.9f;
+        pData->progressBar0_1 = 0.6f;
         if(pars->N_hrir_dirs<=3600){
             pars->weights = realloc1d(pars->weights, pars->N_hrir_dirs*sizeof(float));
             getVoronoiWeights(pars->hrir_dirs_deg, pars->N_hrir_dirs, 0, pars->weights);
         }
         else
-            pars->weights = NULL;
+            pars->weights = malloc1d(pars->N_hrir_dirs*sizeof(float));
+            for(int idx=0; idx < pars->N_hrir_dirs; idx++)
+                pars->weights[idx] = 4.f*SAF_PI / (float)pars->N_hrir_dirs;
+
+        /* HRIR pre-processing */
+        pData->progressBar0_1 = 0.75f;
+        if(pData->preProc != PREPROC_OFF){
+            if(pData->preProc == PREPROC_EQ)
+                diffuseFieldEqualiseHRTFs(pars->N_hrir_dirs, pars->itds_s, pData->freqVector, HYBRID_BANDS, pars->weights, 1, 0, pars->hrtf_fb);
+            if(pData->preProc == PREPROC_PHASE)
+                diffuseFieldEqualiseHRTFs(pars->N_hrir_dirs, pars->itds_s, pData->freqVector, HYBRID_BANDS, pars->weights, 0, 1, pars->hrtf_fb);
+            if(pData->preProc == PREPROC_ALL)
+                diffuseFieldEqualiseHRTFs(pars->N_hrir_dirs, pars->itds_s, pData->freqVector, HYBRID_BANDS, pars->weights, 1, 1, pars->hrtf_fb);
+        }
 
         pData->reinit_hrtfsFLAG = 0;
     }

--- a/examples/src/ambi_bin/ambi_bin.c
+++ b/examples/src/ambi_bin/ambi_bin.c
@@ -61,7 +61,7 @@ void ambi_bin_create
     for (band = 0; band<HYBRID_BANDS; band++)
         pData->EQ[band] = 1.0f;
     pData->useDefaultHRIRsFLAG = 1; /* pars->sofa_filepath must be valid to set this to 0 */
-    pData->enableDiffEQ = 1;
+    pData->preProc = PREPROC_ALL;
     pData->chOrdering = CH_ACN;
     pData->norm = NORM_SN3D;
     pData->enableMaxRE = 1;
@@ -247,9 +247,14 @@ void ambi_bin_initCodec
         pData->progressBar0_1 = 0.6f;
         pars->hrtf_fb = realloc1d(pars->hrtf_fb, HYBRID_BANDS * NUM_EARS * (pars->N_hrir_dirs)*sizeof(float_complex));
         HRIRs2HRTFs_afSTFT(pars->hrirs, pars->N_hrir_dirs, pars->hrir_len, HOP_SIZE, 1, pars->hrtf_fb);
-        if(pData->enableDiffEQ)
-            diffuseFieldEqualiseHRTFs(pars->N_hrir_dirs, pars->itds_s, pData->freqVector, HYBRID_BANDS, pars->hrtf_fb);
-        
+        if(pData->preProc != PREPROC_OFF){
+            if(pData->preProc == PREPROC_EQ)
+                diffuseFieldEqualiseHRTFs(pars->N_hrir_dirs, pars->itds_s, pData->freqVector, HYBRID_BANDS, 1, 0, pars->hrtf_fb);
+            if(pData->preProc == PREPROC_PHASE)
+                diffuseFieldEqualiseHRTFs(pars->N_hrir_dirs, pars->itds_s, pData->freqVector, HYBRID_BANDS, 0, 1, pars->hrtf_fb);
+            if(pData->preProc == PREPROC_ALL)
+                diffuseFieldEqualiseHRTFs(pars->N_hrir_dirs, pars->itds_s, pData->freqVector, HYBRID_BANDS, 1, 1, pars->hrtf_fb);
+        }
         /* get integration weights */
         pData->progressBar0_1 = 0.9f;
         if(pars->N_hrir_dirs<=3600){
@@ -573,6 +578,24 @@ void ambi_bin_setEnableTruncationEQ(void* const hAmbi, int newState)
     }
 }
 
+void ambi_bin_setEnableDiffEQ(void* const hAmbi, int newState)
+{
+/*     ambi_bin_data *pData = (ambi_bin_data*)(hAmbi);
+    if(pData->enablePreProcEQ != newState){
+        pData->enablePreProcEQ = newState;
+        ambi_bin_refreshParams(hAmbi);  // re-init and re-calc
+    } */
+}
+
+void ambi_bin_setHrirPreProc(void* const hAmbi, AMBI_BIN_PREPROC newType)
+{
+    ambi_bin_data *pData = (ambi_bin_data*)(hAmbi);
+    if(pData->preProc != newType){
+        pData->preProc = newType;
+        ambi_bin_refreshParams(hAmbi);
+    }
+}
+
 void ambi_bin_setEnableRotation(void* const hAmbi, int newState)
 {
     ambi_bin_data *pData = (ambi_bin_data*)(hAmbi);
@@ -663,6 +686,18 @@ int ambi_bin_getUseDefaultHRIRsflag(void* const hAmbi)
 {
     ambi_bin_data *pData = (ambi_bin_data*)(hAmbi);
     return pData->useDefaultHRIRsFLAG;
+}
+
+int ambi_bin_getEnableDiffEQ(void* const hAmbi)
+{
+/*     ambi_bin_data *pData = (ambi_bin_data*)(hAmbi);
+    return pData->enablePreProcEQ; */
+}
+
+int ambi_bin_getHrirPreProc(void* const hAmbi)
+{
+    ambi_bin_data *pData = (ambi_bin_data*)(hAmbi);
+    return pData->preProc;
 }
 
 int ambi_bin_getInputOrderPreset(void* const hAmbi)

--- a/examples/src/ambi_bin/ambi_bin_internal.h
+++ b/examples/src/ambi_bin/ambi_bin_internal.h
@@ -150,7 +150,7 @@ typedef struct ambi_bin
     AMBI_BIN_DECODING_METHODS method; /* current decoding method */
     float EQ[HYBRID_BANDS];         /**< EQ curve */
     int useDefaultHRIRsFLAG;        /**< 1: use default HRIRs in database, 0: use those from SOFA file */
-    AMBI_BIN_PREPROC preProc;
+    AMBI_BIN_PREPROC preProc;       /**< HRIR pre-processing strategy */
     CH_ORDER chOrdering;
     NORM_TYPES norm;
     int enableRotation;

--- a/examples/src/ambi_bin/ambi_bin_internal.h
+++ b/examples/src/ambi_bin/ambi_bin_internal.h
@@ -150,7 +150,7 @@ typedef struct ambi_bin
     AMBI_BIN_DECODING_METHODS method; /* current decoding method */
     float EQ[HYBRID_BANDS];         /**< EQ curve */
     int useDefaultHRIRsFLAG;        /**< 1: use default HRIRs in database, 0: use those from SOFA file */
-    int enableDiffEQ;               /**< flag to apply diffuse-field EQ to the currently loaded HRTFs */
+    AMBI_BIN_PREPROC preProc;
     CH_ORDER chOrdering;
     NORM_TYPES norm;
     int enableRotation;

--- a/examples/src/ambi_dec/ambi_dec.c
+++ b/examples/src/ambi_dec/ambi_dec.c
@@ -104,6 +104,7 @@ void ambi_dec_create
     pars->itds_s = NULL;
     pars->hrtf_fb = NULL;
     pars->hrtf_fb_mag = NULL;
+    pars->weights = NULL;
     
     /* internal parameters */ 
     pData->binauraliseLS = pData->new_binauraliseLS = 0;
@@ -149,6 +150,7 @@ void ambi_dec_destroy
         free(pars->itds_s);
         free(pars->hrirs);
         free(pars->hrir_dirs_deg);
+        free(pars->weights);
         for (i=0; i<NUM_DECODERS; i++){
             for(j=0; j<MAX_SH_ORDER; j++){
                 free(pars->M_dec[i][j]);
@@ -407,8 +409,22 @@ void ambi_dec_initCodec
         pData->progressBar0_1 = 0.85f;
         pars->hrtf_fb = realloc1d(pars->hrtf_fb, HYBRID_BANDS * NUM_EARS * (pars->N_hrir_dirs)*sizeof(float_complex));
         HRIRs2HRTFs_afSTFT(pars->hrirs, pars->N_hrir_dirs, pars->hrir_len, HOP_SIZE, 1, pars->hrtf_fb);
-        if(pData->enableDiffEQ)
-            diffuseFieldEqualiseHRTFs(pars->N_hrir_dirs, pars->itds_s, pData->freqVector, HYBRID_BANDS, pars->hrtf_fb);
+        /* HRIR pre-processing */
+        if(pData->enableDiffEQ){
+            /* get integration weights */
+            strcpy(pData->progressBarText,"Applying HRIR Pre-Processing");
+            pData->progressBar0_1 = 0.95f;
+            if(pars->N_hrir_dirs<=3600){
+                pars->weights = realloc1d(pars->weights, pars->N_hrir_dirs*sizeof(float));
+                getVoronoiWeights(pars->hrir_dirs_deg, pars->N_hrir_dirs, 0, pars->weights);
+            }
+            else{
+                pars->weights = malloc1d(pars->N_hrir_dirs*sizeof(float));
+                for(int idx=0; idx < pars->N_hrir_dirs; idx++)
+                    pars->weights[idx] = 4.f*SAF_PI / (float)pars->N_hrir_dirs;
+            }
+            diffuseFieldEqualiseHRTFs(pars->N_hrir_dirs, pars->itds_s, pData->freqVector, HYBRID_BANDS, pars->weights, 1, 0, pars->hrtf_fb);
+        }
         
         /* calculate magnitude responses */
         pars->hrtf_fb_mag = realloc1d(pars->hrtf_fb_mag, HYBRID_BANDS*NUM_EARS*(pars->N_hrir_dirs)*sizeof(float));

--- a/examples/src/ambi_dec/ambi_dec.c
+++ b/examples/src/ambi_dec/ambi_dec.c
@@ -692,6 +692,15 @@ void ambi_dec_setSofaFilePath(void* const hAmbi, const char* path)
     ambi_dec_refreshSettings(hAmbi);  // re-init and re-calc
 }
 
+void ambi_dec_setEnableHRIRsPreProc(void* const hAmbi, int newState)
+{
+    ambi_dec_data *pData = (ambi_dec_data*)(hAmbi);
+    if(newState!=pData->enableHRIRsPreProc){
+        pData->enableHRIRsPreProc = newState;
+        ambi_dec_refreshSettings(hAmbi);  // re-init and re-calc
+    }
+}
+
 void ambi_dec_setOutputConfigPreset(void* const hAmbi, int newPresetID)
 {
     ambi_dec_data *pData = (ambi_dec_data*)(hAmbi);
@@ -920,6 +929,12 @@ char* ambi_dec_getSofaFilePath(void* const hAmbi)
         return pars->sofa_filepath;
     else
         return "no_file";
+}
+
+int ambi_dec_getEnableHRIRsPreProc(void* const hAmbi)
+{
+    ambi_dec_data *pData = (ambi_dec_data*)(hAmbi);
+    return pData->enableHRIRsPreProc;
 }
 
 int ambi_dec_getChOrder(void* const hAmbi)

--- a/examples/src/ambi_dec/ambi_dec.c
+++ b/examples/src/ambi_dec/ambi_dec.c
@@ -61,7 +61,7 @@ void ambi_dec_create
     for (band = 0; band<HYBRID_BANDS; band++)
         pData->orderPerBand[band] = 1;
     pData->useDefaultHRIRsFLAG = 1; /* pars->sofa_filepath must be valid to set this to 0 */
-    pData->enableDiffEQ = 1;
+    pData->enableHRIRsPreProc = 1;
     pData->nLoudpkrs = pData->new_nLoudpkrs;
     pData->chOrdering = CH_ACN;
     pData->norm = NORM_SN3D;
@@ -410,7 +410,7 @@ void ambi_dec_initCodec
         pars->hrtf_fb = realloc1d(pars->hrtf_fb, HYBRID_BANDS * NUM_EARS * (pars->N_hrir_dirs)*sizeof(float_complex));
         HRIRs2HRTFs_afSTFT(pars->hrirs, pars->N_hrir_dirs, pars->hrir_len, HOP_SIZE, 1, pars->hrtf_fb);
         /* HRIR pre-processing */
-        if(pData->enableDiffEQ){
+        if(pData->enableHRIRsPreProc){
             /* get integration weights */
             strcpy(pData->progressBarText,"Applying HRIR Pre-Processing");
             pData->progressBar0_1 = 0.95f;

--- a/examples/src/ambi_dec/ambi_dec_internal.h
+++ b/examples/src/ambi_dec/ambi_dec_internal.h
@@ -111,6 +111,9 @@ typedef struct _ambi_dec_codecPars
     float* hrtf_fb_mag;                         /**< magnitudes of the HRTF filterbank coefficients; nBands x nCH x N_hrirs */
     float_complex hrtf_interp[MAX_NUM_LOUDSPEAKERS][HYBRID_BANDS][NUM_EARS]; /* interpolated HRTFs */
     
+    /* integration weights */
+    float* weights;         /**< grid integration weights of hrirs; N_hrirs x 1 */
+
 }ambi_dec_codecPars;
 
 /**

--- a/examples/src/ambi_dec/ambi_dec_internal.h
+++ b/examples/src/ambi_dec/ambi_dec_internal.h
@@ -160,7 +160,7 @@ typedef struct _ambi_dec
     int nLoudpkrs;                       /**< number of loudspeakers/virtual loudspeakers */
     float loudpkrs_dirs_deg[MAX_NUM_LOUDSPEAKERS][NUM_DECODERS]; /* loudspeaker directions in degrees [azi, elev] */
     int useDefaultHRIRsFLAG;             /**< 1: use default HRIRs in database, 0: use those from SOFA file */
-    int enableDiffEQ;                    /**< flag to apply diffuse-field EQ to the currently loaded HRTFs */
+    int enableHRIRsPreProc;              /**< flag to apply pre-processing to the currently loaded HRTFs */
     int binauraliseLS;                   /**< 1: convolve loudspeaker signals with HRTFs, 0: output loudspeaker signals */
     CH_ORDER chOrdering;                 /**< only ACN is supported */
     NORM_TYPES norm;                     /**< N3D or SN3D */

--- a/examples/src/binauraliser/binauraliser.c
+++ b/examples/src/binauraliser/binauraliser.c
@@ -548,7 +548,6 @@ int binauraliser_getEnableHRIRsPreProc(void* const hBin)
     return pData->enableHRIRsPreProc;
 }
 
-
 int binauraliser_getDAWsamplerate(void* const hBin)
 {
     binauraliser_data *pData = (binauraliser_data*)(hBin);

--- a/examples/src/binauraliser/binauraliser.c
+++ b/examples/src/binauraliser/binauraliser.c
@@ -68,6 +68,7 @@ void binauraliser_create
     pData->hrirs = NULL;
     pData->hrir_dirs_deg = NULL;
     pData->sofa_filepath = NULL;
+    pData->weights = NULL;
     
     /* vbap (amplitude normalised) */
     pData->hrtf_vbap_gtableIdx = NULL;
@@ -118,6 +119,7 @@ void binauraliser_destroy
         free(pData->itds_s);
         free(pData->hrirs);
         free(pData->hrir_dirs_deg);
+        free(pData->weights);
         free(pData->progressBarText);
          
         free(pData);

--- a/examples/src/binauraliser/binauraliser.c
+++ b/examples/src/binauraliser/binauraliser.c
@@ -45,7 +45,7 @@ void binauraliser_create
     /* user parameters */
     binauraliser_loadPreset(SOURCE_CONFIG_PRESET_DEFAULT, pData->src_dirs_deg, &(pData->new_nSources), &(pData->input_nDims)); /*check setStateInformation if you change default preset*/
     pData->useDefaultHRIRsFLAG = 1; /* pars->sofa_filepath must be valid to set this to 0 */
-    pData->enableDiffEQ = 1;
+    pData->enableHRIRsPreProc = 1;
     pData->nSources = pData->new_nSources;
     pData->interpMode = INTERP_TRI;
     pData->yaw = 0.0f;
@@ -338,6 +338,15 @@ void binauraliser_setSofaFilePath(void* const hBin, const char* path)
     binauraliser_refreshSettings(hBin);  // re-init and re-calc
 }
 
+void binauraliser_setEnableHRTFsPreProc(void* const hBin, int newState)
+{
+    binauraliser_data *pData = (binauraliser_data*)(hBin);
+    if(newState!=pData->enableHRIRsPreProc){
+        pData->enableHRIRsPreProc = newState;
+        binauraliser_refreshSettings(hBin);  // re-init and re-calc
+    }
+}
+
 void binauraliser_setInputConfigPreset(void* const hBin, int newPresetID)
 {
     binauraliser_data *pData = (binauraliser_data*)(hBin);
@@ -421,14 +430,6 @@ void binauraliser_setInterpMode(void* const hBin, int newMode)
     pData->interpMode = newMode;
 }
 
-void binauraliser_setEnableHRTFDiffuseEQ(void* const hBin, int newState)
-{
-    binauraliser_data *pData = (binauraliser_data*)(hBin);
-    if(newState!=pData->enableDiffEQ){
-        pData->enableDiffEQ = newState;
-        binauraliser_refreshSettings(hBin);  // re-init and re-calc
-    }
-}
 
 
 /* Get Functions */
@@ -541,6 +542,13 @@ char* binauraliser_getSofaFilePath(void* const hBin)
         return "no_file";
 }
 
+int binauraliser_getEnableHRIRsPreProc(void* const hBin)
+{
+    binauraliser_data *pData = (binauraliser_data*)(hBin);
+    return pData->enableHRIRsPreProc;
+}
+
+
 int binauraliser_getDAWsamplerate(void* const hBin)
 {
     binauraliser_data *pData = (binauraliser_data*)(hBin);
@@ -604,10 +612,4 @@ int binauraliser_getInterpMode(void* const hBin)
 int binauraliser_getProcessingDelay()
 {
     return 12*HOP_SIZE;
-}
-
-int binauraliser_getEnableHRTFDiffuseEQ(void* const hBin)
-{
-    binauraliser_data *pData = (binauraliser_data*)(hBin);
-    return pData->enableDiffEQ;
 }

--- a/examples/src/binauraliser/binauraliser.c
+++ b/examples/src/binauraliser/binauraliser.c
@@ -338,7 +338,7 @@ void binauraliser_setSofaFilePath(void* const hBin, const char* path)
     binauraliser_refreshSettings(hBin);  // re-init and re-calc
 }
 
-void binauraliser_setEnableHRTFsPreProc(void* const hBin, int newState)
+void binauraliser_setEnableHRIRsPreProc(void* const hBin, int newState)
 {
     binauraliser_data *pData = (binauraliser_data*)(hBin);
     if(newState!=pData->enableHRIRsPreProc){

--- a/examples/src/binauraliser/binauraliser_internal.c
+++ b/examples/src/binauraliser/binauraliser_internal.c
@@ -177,7 +177,7 @@ void binauraliser_initHRTFsAndGainTables(void* const hBin)
     pData->hrtf_fb = realloc1d(pData->hrtf_fb, HYBRID_BANDS * NUM_EARS * (pData->N_hrir_dirs)*sizeof(float_complex));
     HRIRs2HRTFs_afSTFT(pData->hrirs, pData->N_hrir_dirs, pData->hrir_len, HOP_SIZE, 1, pData->hrtf_fb);
     /* HRIR pre-processing */
-    if(pData->enableDiffEQ){
+    if(pData->enableHRIRsPreProc){
         /* get integration weights */
         strcpy(pData->progressBarText,"Applying HRIR Pre-Processing");
         pData->progressBar0_1 = 0.9f;

--- a/examples/src/binauraliser/binauraliser_internal.h
+++ b/examples/src/binauraliser/binauraliser_internal.h
@@ -90,6 +90,7 @@ typedef struct _binauraliser
     int N_hrir_dirs;
     int hrir_len;
     int hrir_fs;
+    float* weights;
     
     /* vbap gain table */
     int hrtf_vbapTableRes[2];

--- a/examples/src/binauraliser/binauraliser_internal.h
+++ b/examples/src/binauraliser/binauraliser_internal.h
@@ -127,7 +127,7 @@ typedef struct _binauraliser
     float src_dirs_deg[MAX_NUM_INPUTS][2];
     INTERP_MODES interpMode;
     int useDefaultHRIRsFLAG;                 /**< 1: use default HRIRs in database, 0: use those from SOFA file */
-    int enableDiffEQ;                        /**< flag to apply diffuse-field EQ to the currently loaded HRTFs */
+    int enableHRIRsPreProc;                  /**< flag to apply pre-processing to the currently loaded HRTFs */
     int enableRotation;
     float yaw, roll, pitch;                  /**< rotation angles in degrees */
     int bFlipYaw, bFlipPitch, bFlipRoll;     /**< flag to flip the sign of the individual rotation angles */

--- a/framework/modules/saf_hrir/saf_hrir.c
+++ b/framework/modules/saf_hrir/saf_hrir.c
@@ -173,6 +173,7 @@ void diffuseFieldEqualiseHRTFs
     float* itds_s,
     float* centreFreq,
     int N_bands,
+    float* weights,
     int applyEQ,
     int applyPhase,
     float_complex* hrtfs   /* N_bands x 2 x N_dirs */
@@ -187,13 +188,15 @@ void diffuseFieldEqualiseHRTFs
         /* diffuse-field equalise */
         if(applyEQ){
             hrtf_diff = calloc1d(N_bands*NUM_EARS, sizeof(float));
+            if(weights == NULL)
+                assert(0);
             for(band=0; band<N_bands; band++)
                 for(i=0; i<NUM_EARS; i++)
                     for(j=0; j<N_dirs; j++)
-                        hrtf_diff[band*NUM_EARS + i] += powf(cabsf(hrtfs[band*NUM_EARS*N_dirs + i*N_dirs + j]), 2.0f);
+                        hrtf_diff[band*NUM_EARS + i] += weights[j]/(4.f*SAF_PI) * powf(cabsf(hrtfs[band*NUM_EARS*N_dirs + i*N_dirs + j]), 2.0f);
             for(band=0; band<N_bands; band++)
                 for(i=0; i<NUM_EARS; i++)
-                    hrtf_diff[band*NUM_EARS + i] = sqrtf(hrtf_diff[band*NUM_EARS + i]/(float)N_dirs);
+                    hrtf_diff[band*NUM_EARS + i] = sqrtf(hrtf_diff[band*NUM_EARS + i]);
             for(band=0; band<N_bands; band++)
                 for(i=0; i<NUM_EARS; i++)
                     for(nd=0; nd<N_dirs; nd++)

--- a/framework/modules/saf_hrir/saf_hrir.c
+++ b/framework/modules/saf_hrir/saf_hrir.c
@@ -183,45 +183,45 @@ void diffuseFieldEqualiseHRTFs
     {
         int i, j, nd, band;
         float* ipd, *hrtf_diff;
-        /* convert ITDs to phase differences -pi..pi */
-        ipd = malloc1d(N_bands*N_dirs*sizeof(float));
-        cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, N_bands, N_dirs, 1, 1.0,
-                    centreFreq, 1,
-                    itds_s, 1, 0.0,
-                    ipd, N_dirs);
-        for(i=0; i<N_bands; i++)
-            for(j=0; j<N_dirs; j++)
-                ipd[i*N_dirs+j] = (matlab_fmodf(2.0f*SAF_PI*ipd[i*N_dirs+j] + SAF_PI, 2.0f*SAF_PI) - SAF_PI)/2.0f; /* /2 here, not later */
-        
+      
         /* diffuse-field equalise */
-        hrtf_diff = calloc1d(N_bands*NUM_EARS, sizeof(float));
-        for(band=0; band<N_bands; band++)
-            for(i=0; i<NUM_EARS; i++)
-                for(j=0; j<N_dirs; j++)
-                    hrtf_diff[band*NUM_EARS + i] += powf(cabsf(hrtfs[band*NUM_EARS*N_dirs + i*N_dirs + j]), 2.0f);
-        for(band=0; band<N_bands; band++)
-            for(i=0; i<NUM_EARS; i++)
-                hrtf_diff[band*NUM_EARS + i] = sqrtf(hrtf_diff[band*NUM_EARS + i]/(float)N_dirs);
         if(applyEQ){
+            hrtf_diff = calloc1d(N_bands*NUM_EARS, sizeof(float));
+            for(band=0; band<N_bands; band++)
+                for(i=0; i<NUM_EARS; i++)
+                    for(j=0; j<N_dirs; j++)
+                        hrtf_diff[band*NUM_EARS + i] += powf(cabsf(hrtfs[band*NUM_EARS*N_dirs + i*N_dirs + j]), 2.0f);
+            for(band=0; band<N_bands; band++)
+                for(i=0; i<NUM_EARS; i++)
+                    hrtf_diff[band*NUM_EARS + i] = sqrtf(hrtf_diff[band*NUM_EARS + i]/(float)N_dirs);
             for(band=0; band<N_bands; band++)
                 for(i=0; i<NUM_EARS; i++)
                     for(nd=0; nd<N_dirs; nd++)
                         hrtfs[band*NUM_EARS*N_dirs + i*N_dirs + nd] = ccdivf(hrtfs[band*NUM_EARS*N_dirs + i*N_dirs + nd], cmplxf(hrtf_diff[band*NUM_EARS + i] + 2.23e-8f, 0.0f));
+            free(hrtf_diff);
         }
         
         /* create complex HRTFs by introducing the interaural phase differences
         * (IPDs) to the HRTF magnitude responses */
         if(applyPhase){
+            /* convert ITDs to phase differences -pi..pi */
+            ipd = malloc1d(N_bands*N_dirs*sizeof(float));
+            cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, N_bands, N_dirs, 1, 1.0,
+                        centreFreq, 1,
+                        itds_s, 1, 0.0,
+                        ipd, N_dirs);
+            for(i=0; i<N_bands; i++)
+                for(j=0; j<N_dirs; j++)
+                    ipd[i*N_dirs+j] = (matlab_fmodf(2.0f*SAF_PI*ipd[i*N_dirs+j] + SAF_PI, 2.0f*SAF_PI) - SAF_PI)/2.0f; /* /2 here, not later */
+  
             for(band=0; band<N_bands; band++){
                 for(nd=0; nd<N_dirs; nd++){
                     hrtfs[band*NUM_EARS*N_dirs + 0*N_dirs + nd] = crmulf( cexpf(cmplxf(0.0f, ipd[band*N_dirs + nd])), cabsf(hrtfs[band*NUM_EARS*N_dirs + 0*N_dirs + nd]) );
                     hrtfs[band*NUM_EARS*N_dirs + 1*N_dirs + nd] = crmulf( cexpf(cmplxf(0.0f,-ipd[band*N_dirs + nd])), cabsf(hrtfs[band*NUM_EARS*N_dirs + 1*N_dirs + nd]) );
                 }
             }
+            free(ipd);
         }
-        
-        free(ipd);
-        free(hrtf_diff);
     }
 
 }

--- a/framework/modules/saf_hrir/saf_hrir.c
+++ b/framework/modules/saf_hrir/saf_hrir.c
@@ -189,7 +189,7 @@ void diffuseFieldEqualiseHRTFs
         if(applyEQ){
             hrtf_diff = calloc1d(N_bands*NUM_EARS, sizeof(float));
             if(weights == NULL)
-                assert(0);
+                assert(0);  // Not good, could be cought
             for(band=0; band<N_bands; band++)
                 for(i=0; i<NUM_EARS; i++)
                     for(j=0; j<N_dirs; j++)

--- a/framework/modules/saf_hrir/saf_hrir.h
+++ b/framework/modules/saf_hrir/saf_hrir.h
@@ -164,6 +164,8 @@ void diffuseFieldEqualiseHRTFs(/* Input Arguments */
                                float* itds_s,
                                float* centreFreq,
                                int N_bands,
+                               int applyEQ,
+                               int applyPhase,
                                /* Input/Output Arguments */
                                float_complex* hrtfs);
 

--- a/framework/modules/saf_hrir/saf_hrir.h
+++ b/framework/modules/saf_hrir/saf_hrir.h
@@ -148,7 +148,9 @@ void HRIRs2HRTFs(/* Input Arguments */
                  float_complex* hrtfs);
 
 /**
- * Applies diffuse-field equalisation to a set of HRTFs
+ * Applies pre-processing to a set of HRTFs. Can be diffuse field EQ of a 
+ * weighted (weights should sum to 4pi) average of all HRTFs (CTF).
+ * Also provides phase simplification based on ITDs.
  *
  * @warning This function is NOT suitable for binaural room impulse responses
  *          (BRIRs)!
@@ -157,6 +159,9 @@ void HRIRs2HRTFs(/* Input Arguments */
  * @param[in]     itds_s     HRIR ITDs; N_dirs x 1
  * @param[in]     centreFreq Frequency vector; N_bands x 1
  * @param[in]     N_bands    Number of frequency bands/bins
+ * @param[in]     weights    Grid weights (sum to 4pi); N_dirs x 1
+ * @param[in]     applyEQ    EQ diffuse field / CTF; 0:disabled, 1:enabled
+ * @param[in]     applyPhase Phase simplification; 0:disabled, 1:enabled
  * @param[in,out] hrtfs      The HRTFs; FLAT: N_bands x #NUM_EARS x N_dirs
  */
 void diffuseFieldEqualiseHRTFs(/* Input Arguments */

--- a/framework/modules/saf_hrir/saf_hrir.h
+++ b/framework/modules/saf_hrir/saf_hrir.h
@@ -164,6 +164,7 @@ void diffuseFieldEqualiseHRTFs(/* Input Arguments */
                                float* itds_s,
                                float* centreFreq,
                                int N_bands,
+                               float* weights,
                                int applyEQ,
                                int applyPhase,
                                /* Input/Output Arguments */


### PR DESCRIPTION

## What is the goal of this PR?

Extend the current HRTF pre-processing strategies and make them accessible.

## What are the changes implemented in this PR?

Getter and Setter, as well as modularized pre-processing. Furthermore, the common transfer function is calculated more precisely considering grid weights, resulting in an improved diffuse field EQ.
