### PR TITLE
Add CMake option to disable printing of version and license

### DIFF
--- a/examples/src/ambi_bin/ambi_bin.c
+++ b/examples/src/ambi_bin/ambi_bin.c
@@ -55,7 +55,7 @@ void ambi_bin_create
     *phAmbi = (void*)pData;
     int band;
 
-    printf(SAF_VERSION_LICENSE_STRING);
+    SAF_PRINT_VERSION_LICENSE_STRING;
 
     /* default user parameters */
     for (band = 0; band<HYBRID_BANDS; band++)

--- a/examples/src/ambi_dec/ambi_dec.c
+++ b/examples/src/ambi_dec/ambi_dec.c
@@ -53,7 +53,7 @@ void ambi_dec_create
     *phAmbi = (void*)pData;
     int i, j, ch, band;
 
-    printf(SAF_VERSION_LICENSE_STRING);
+    SAF_PRINT_VERSION_LICENSE_STRING;
 
     /* default user parameters */
     loadLoudspeakerArrayPreset(LOUDSPEAKER_ARRAY_PRESET_T_DESIGN_24, pData->loudpkrs_dirs_deg, &(pData->new_nLoudpkrs), &(pData->loudpkrs_nDims));

--- a/examples/src/ambi_drc/ambi_drc.c
+++ b/examples/src/ambi_drc/ambi_drc.c
@@ -47,7 +47,7 @@ void ambi_drc_create
     ambi_drc_data* pData = (ambi_drc_data*)malloc1d(sizeof(ambi_drc_data));
     *phAmbi = (void*)pData;
 
-    printf(SAF_VERSION_LICENSE_STRING);
+    SAF_PRINT_VERSION_LICENSE_STRING;
  
     /* afSTFT stuff and audio buffers*/
     pData->hSTFT = NULL;

--- a/examples/src/ambi_enc/ambi_enc.c
+++ b/examples/src/ambi_enc/ambi_enc.c
@@ -34,7 +34,7 @@ void ambi_enc_create
     *phAmbi = (void*)pData;
     int i;
 
-    printf(SAF_VERSION_LICENSE_STRING);
+    SAF_PRINT_VERSION_LICENSE_STRING;
 
     pData->order = 1;
     

--- a/examples/src/ambi_roomsim/ambi_roomsim.c
+++ b/examples/src/ambi_roomsim/ambi_roomsim.c
@@ -38,7 +38,7 @@ void ambi_roomsim_create
     ambi_roomsim_data* pData = (ambi_roomsim_data*)malloc1d(sizeof(ambi_roomsim_data));
     *phAmbi = (void*)pData;
     
-    printf(SAF_VERSION_LICENSE_STRING);
+    SAF_PRINT_VERSION_LICENSE_STRING;
 
     /* default user parameters */
     pData->enableReflections = 1;

--- a/examples/src/array2sh/array2sh.c
+++ b/examples/src/array2sh/array2sh.c
@@ -56,7 +56,7 @@ void array2sh_create
     array2sh_data* pData = (array2sh_data*)malloc1d(sizeof(array2sh_data));
     *phA2sh = (void*)pData;
 
-    printf(SAF_VERSION_LICENSE_STRING);
+    SAF_PRINT_VERSION_LICENSE_STRING;
 
     /* defualt parameters */
     array2sh_createArray(&(pData->arraySpecs)); 

--- a/examples/src/beamformer/beamformer.c
+++ b/examples/src/beamformer/beamformer.c
@@ -34,7 +34,7 @@ void beamformer_create
     *phBeam = (void*)pData;
     int i, ch;
 
-    printf(SAF_VERSION_LICENSE_STRING);
+    SAF_PRINT_VERSION_LICENSE_STRING;
 
     /* default user parameters */
     pData->beamOrder = 1;

--- a/examples/src/binauraliser/binauraliser.c
+++ b/examples/src/binauraliser/binauraliser.c
@@ -40,7 +40,7 @@ void binauraliser_create
     *phBin = (void*)pData;
     int ch;
 
-    printf(SAF_VERSION_LICENSE_STRING);
+    SAF_PRINT_VERSION_LICENSE_STRING;
 
     /* user parameters */
     binauraliser_loadPreset(SOURCE_CONFIG_PRESET_DEFAULT, pData->src_dirs_deg, &(pData->new_nSources), &(pData->input_nDims)); /*check setStateInformation if you change default preset*/

--- a/examples/src/decorrelator/decorrelator.c
+++ b/examples/src/decorrelator/decorrelator.c
@@ -32,7 +32,7 @@ void decorrelator_create
     decorrelator_data* pData = (decorrelator_data*)malloc1d(sizeof(decorrelator_data));
     *phDecor = (void*)pData;
 
-    printf(SAF_VERSION_LICENSE_STRING);
+    SAF_PRINT_VERSION_LICENSE_STRING;
 
     /* default user parameters */
     pData->nChannels = 1;

--- a/examples/src/dirass/dirass.c
+++ b/examples/src/dirass/dirass.c
@@ -45,7 +45,7 @@ void dirass_create
     *phDir = (void*)pData;
     int i;
 
-    printf(SAF_VERSION_LICENSE_STRING);
+    SAF_PRINT_VERSION_LICENSE_STRING;
 
     /* Default user parameters */
     pData->inputOrder = pData->new_inputOrder = SH_ORDER_FIRST;

--- a/examples/src/matrixconv/matrixconv.c
+++ b/examples/src/matrixconv/matrixconv.c
@@ -32,7 +32,7 @@ void matrixconv_create
     matrixconv_data* pData = (matrixconv_data*)malloc1d(sizeof(matrixconv_data));
     *phMCnv = (void*)pData;
 
-    printf(SAF_VERSION_LICENSE_STRING);
+    SAF_PRINT_VERSION_LICENSE_STRING;
     
     /* Default user parameters */
     pData->nInputChannels = 1;

--- a/examples/src/multiconv/multiconv.c
+++ b/examples/src/multiconv/multiconv.c
@@ -32,7 +32,7 @@ void multiconv_create
     multiconv_data* pData = (multiconv_data*)malloc1d(sizeof(multiconv_data));
     *phMCnv = (void*)pData;
 
-    printf(SAF_VERSION_LICENSE_STRING);
+    SAF_PRINT_VERSION_LICENSE_STRING;
 
     /* Default user parameters */
     pData->nChannels = 1;

--- a/examples/src/panner/panner.c
+++ b/examples/src/panner/panner.c
@@ -51,7 +51,7 @@ void panner_create
     *phPan = (void*)pData;
     int ch, dummy;
 
-    printf(SAF_VERSION_LICENSE_STRING);
+    SAF_PRINT_VERSION_LICENSE_STRING;
 
     /* default user parameters */
     panner_loadSourcePreset(SOURCE_CONFIG_PRESET_DEFAULT, pData->src_dirs_deg, &(pData->new_nSources), &(dummy)); /*check setStateInformation if you change default preset*/

--- a/examples/src/pitch_shifter/pitch_shifter.c
+++ b/examples/src/pitch_shifter/pitch_shifter.c
@@ -33,7 +33,7 @@ void pitch_shifter_create
     pitch_shifter_data* pData = (pitch_shifter_data*)malloc1d(sizeof(pitch_shifter_data));
     *phPS = (void*)pData;
 
-    printf(SAF_VERSION_LICENSE_STRING);
+    SAF_PRINT_VERSION_LICENSE_STRING;
     
     /* Default user parameters */
     pData->new_nChannels = pData->nChannels = 1;

--- a/examples/src/powermap/powermap.c
+++ b/examples/src/powermap/powermap.c
@@ -40,7 +40,7 @@ void powermap_create
     *phPm = (void*)pData;
     int n, i, band;
 
-    printf(SAF_VERSION_LICENSE_STRING);
+    SAF_PRINT_VERSION_LICENSE_STRING;
     
     /* Default user parameters */
     pData->masterOrder = pData->new_masterOrder = SH_ORDER_FIRST;

--- a/examples/src/rotator/rotator.c
+++ b/examples/src/rotator/rotator.c
@@ -41,7 +41,7 @@ void rotator_create
     rotator_data* pData = (rotator_data*)malloc1d(sizeof(rotator_data));
     *phRot = (void*)pData;
 
-    printf(SAF_VERSION_LICENSE_STRING);
+    SAF_PRINT_VERSION_LICENSE_STRING;
     
     pData->M_rot_status = M_ROT_RECOMPUTE_QUATERNION;
   

--- a/examples/src/sldoa/sldoa.c
+++ b/examples/src/sldoa/sldoa.c
@@ -55,7 +55,7 @@ void sldoa_create
     *phSld = (void*)pData;
     int i, j, band;
 
-    printf(SAF_VERSION_LICENSE_STRING);
+    SAF_PRINT_VERSION_LICENSE_STRING;
 
     /* Default user parameters */
     pData->new_masterOrder = pData->masterOrder = 1;

--- a/examples/src/spreader/spreader.c
+++ b/examples/src/spreader/spreader.c
@@ -33,7 +33,7 @@ void spreader_create
     *phSpr = (void*)pData;
     int band, t, src;
 
-    printf(SAF_VERSION_LICENSE_STRING);
+    SAF_PRINT_VERSION_LICENSE_STRING;
 
     /* user parameters */
     pData->sofa_filepath = NULL;

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -246,6 +246,14 @@ endif()
 
 
 ############################################################################
+# Disable print of SAF version and license
+if(SAF_DISABLE_PRINT_VERSION)
+    message(STATUS "saf version and license printing disabled. ")
+    target_compile_definitions(${PROJECT_NAME} PUBLIC SAF_DISABLE_PRINT_VERSION=${SAF_DISABLE_PRINT_VERSION})
+endif()
+
+
+############################################################################
 if(UNIX)
     target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra)
 endif()

--- a/framework/include/saf.h
+++ b/framework/include/saf.h
@@ -118,6 +118,12 @@
   "   (_______) |_|   |_| |_|   (Version: " SAF_VERSION_STRING ", License:"   \
   " " SAF_LICENSE_STRING ")                                              \n\n"
 
+/** Printing the Spatial_Audio_Framework Version and License as a string */
+#ifdef SAF_DISABLE_PRINT_VERSION
+#define SAF_PRINT_VERSION_LICENSE_STRING
+#else
+#define SAF_PRINT_VERSION_LICENSE_STRING printf(SAF_VERSION_LICENSE_STRING)
+#endif
 
 /* ========================================================================== */
 /*                                Core Modules                                */


### PR DESCRIPTION
Use a conditional macro for the printf statement everywhere

## What is the goal of this PR?

It should be possible to disable printing of the SAF version and license string in all example create methods (for instance `ambi_bin_create`). They produce numerous lines of distracting console output in our regression test suite.

## What are the changes implemented in this PR?

Instead of an explicit printf in each create method, I have added a print macro that could be left empty with the CMake option `SAF_DISABLE_PRINT_VERSION`. Printing is default on and must be explicitly disabled. 

The simplest option would be to remove the print statements entirely, but I assume they're in there for a reason.
