### PR TITLE
Replace M_PI by SAF_PI

### DIFF
--- a/examples/src/ambi_dec/ambi_dec.c
+++ b/examples/src/ambi_dec/ambi_dec.c
@@ -304,8 +304,8 @@ void ambi_dec_initCodec
             Y = malloc1d(nSH_order*sizeof(float));
             grid_dirs_deg = (float*)(&__Tdesign_degree_30_dirs_deg[0][0]);
             for(ng=0; ng<nGrid_dirs; ng++){
-                azi_incl[0] = grid_dirs_deg[ng*2]*M_PI/180.0f;
-                azi_incl[1] = M_PI/2.0f-grid_dirs_deg[ng*2+1]*M_PI/180.0f;
+                azi_incl[0] = grid_dirs_deg[ng*2]*SAF_PI/180.0f;
+                azi_incl[1] = SAF_PI/2.0f-grid_dirs_deg[ng*2+1]*SAF_PI/180.0f;
                 getSHreal(n, (float*)azi_incl, 1,  Y);
                 cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, nLoudspeakers, 1, nSH_order, 1.0f,
                             pars->M_dec[d][n-1], nSH_order,

--- a/examples/src/ambi_dec/ambi_dec_internal.c
+++ b/examples/src/ambi_dec/ambi_dec_internal.c
@@ -296,7 +296,7 @@ void loadLoudspeakerArrayPreset
     /* Fill remaining slots with default coords */
     for(; ch<MAX_NUM_LOUDSPEAKERS; ch++)
         for(i=0; i<2; i++)
-            dirs_deg[ch][i] = __default_LScoords64_rad[ch][i]* (180.0f/M_PI);
+            dirs_deg[ch][i] = __default_LScoords64_rad[ch][i]* (180.0f/SAF_PI);
     
     /* specify new number of channels (for dynamically changing the number of TFT channels) */
     (*newNCH) = nCH;

--- a/examples/src/ambi_enc/ambi_enc_internal.c
+++ b/examples/src/ambi_enc/ambi_enc_internal.c
@@ -218,7 +218,7 @@ void loadSourceConfigPreset
     /* Fill remaining slots with default coords */
     for(; ch<MAX_NUM_INPUTS; ch++)
         for(i=0; i<2; i++)
-            dirs_deg[ch][i] = __default_LScoords64_rad[ch][i]* (180.0f/M_PI);
+            dirs_deg[ch][i] = __default_LScoords64_rad[ch][i]* (180.0f/SAF_PI);
     
     /* specify new number of channels (for dynamically changing the number of TFT channels) */
     (*newNCH) = nCH; 

--- a/examples/src/array2sh/array2sh.c
+++ b/examples/src/array2sh/array2sh.c
@@ -326,7 +326,7 @@ void array2sh_setSensorAzi_rad(void* const hA2sh, int index, float newAzi_rad)
     
     if(arraySpecs->sensorCoords_rad[index][0] != newAzi_rad){
         arraySpecs->sensorCoords_rad[index][0] = newAzi_rad;
-        arraySpecs->sensorCoords_deg[index][0] = newAzi_rad * (180.0f/M_PI);
+        arraySpecs->sensorCoords_deg[index][0] = newAzi_rad * (180.0f/SAF_PI);
         pData->reinitSHTmatrixFLAG = 1;
         array2sh_setEvalStatus(hA2sh, EVAL_STATUS_NOT_EVALUATED);
     }
@@ -339,7 +339,7 @@ void array2sh_setSensorElev_rad(void* const hA2sh, int index, float newElev_rad)
     
     if(arraySpecs->sensorCoords_rad[index][1] != newElev_rad){
         arraySpecs->sensorCoords_rad[index][1] = newElev_rad;
-        arraySpecs->sensorCoords_deg[index][1] = newElev_rad * (180.0f/M_PI);
+        arraySpecs->sensorCoords_deg[index][1] = newElev_rad * (180.0f/SAF_PI);
         pData->reinitSHTmatrixFLAG = 1;
         array2sh_setEvalStatus(hA2sh, EVAL_STATUS_NOT_EVALUATED);
     }
@@ -352,7 +352,7 @@ void array2sh_setSensorAzi_deg(void* const hA2sh, int index, float newAzi_deg)
     array2sh_arrayPars* arraySpecs = (array2sh_arrayPars*)(pData->arraySpecs);
     
     if(arraySpecs->sensorCoords_deg[index][0] != newAzi_deg){
-        arraySpecs->sensorCoords_rad[index][0] = newAzi_deg * (M_PI/180.0f);
+        arraySpecs->sensorCoords_rad[index][0] = newAzi_deg * (SAF_PI/180.0f);
         arraySpecs->sensorCoords_deg[index][0] = newAzi_deg;
         pData->reinitSHTmatrixFLAG = 1;
         array2sh_setEvalStatus(hA2sh, EVAL_STATUS_NOT_EVALUATED);
@@ -365,7 +365,7 @@ void array2sh_setSensorElev_deg(void* const hA2sh, int index, float newElev_deg)
     array2sh_arrayPars* arraySpecs = (array2sh_arrayPars*)(pData->arraySpecs);
     
     if(arraySpecs->sensorCoords_deg[index][1] != newElev_deg){
-        arraySpecs->sensorCoords_rad[index][1] = newElev_deg * (M_PI/180.0f);
+        arraySpecs->sensorCoords_rad[index][1] = newElev_deg * (SAF_PI/180.0f);
         arraySpecs->sensorCoords_deg[index][1] = newElev_deg;
         pData->reinitSHTmatrixFLAG = 1;
         array2sh_setEvalStatus(hA2sh, EVAL_STATUS_NOT_EVALUATED);

--- a/examples/src/beamformer/beamformer.c
+++ b/examples/src/beamformer/beamformer.c
@@ -38,10 +38,10 @@ void beamformer_create
     /* default user parameters */
     pData->beamOrder = 1;
     for(i=0; i<MAX_NUM_BEAMS; i++){
-        pData->beam_dirs_deg[i][0] = __default_LScoords64_rad[i][0]*180.0f/M_PI;
-        pData->beam_dirs_deg[i][1] = (__default_LScoords64_rad[i][1] - M_PI/2.0f) < -M_PI/2.0f ?
-        (M_PI/2.0f + __default_LScoords64_rad[i][1]) :  (__default_LScoords64_rad[i][1] - M_PI/2.0f);
-        pData->beam_dirs_deg[i][1] *= 180.0f/M_PI;
+        pData->beam_dirs_deg[i][0] = __default_LScoords64_rad[i][0]*180.0f/SAF_PI;
+        pData->beam_dirs_deg[i][1] = (__default_LScoords64_rad[i][1] - SAF_PI/2.0f) < -SAF_PI/2.0f ?
+        (SAF_PI/2.0f + __default_LScoords64_rad[i][1]) :  (__default_LScoords64_rad[i][1] - SAF_PI/2.0f);
+        pData->beam_dirs_deg[i][1] *= 180.0f/SAF_PI;
     }
     pData->nBeams = 1;
     pData->beamType = STATIC_BEAM_TYPE_HYPERCARDIOID;

--- a/examples/src/binauraliser/binauraliser_internal.c
+++ b/examples/src/binauraliser/binauraliser_internal.c
@@ -468,7 +468,7 @@ void binauraliser_loadPreset
     /* Fill remaining slots with default coords */
     for(; ch<MAX_NUM_INPUTS; ch++){
         for(i=0; i<2; i++){
-            dirs_deg[ch][i] = __default_LScoords64_rad[ch][i]* (180.0f/M_PI);
+            dirs_deg[ch][i] = __default_LScoords64_rad[ch][i]* (180.0f/SAF_PI);
         }
     }
     

--- a/examples/src/dirass/dirass.c
+++ b/examples/src/dirass/dirass.c
@@ -302,7 +302,7 @@ void dirass_analysis
                         pars->est_dirs[i*2] = atan2f(intensity[1], intensity[0]);
                         pars->est_dirs[i*2+1] = atan2f(intensity[2], sqrtf(powf(intensity[0], 2.0f) + powf(intensity[1], 2.0f)));
                         if(DirAssMode==REASS_UPSCALE)
-                            pars->est_dirs[i*2+1] = M_PI/2.0f - pars->est_dirs[i*2+1]; /* convert to inclination */
+                            pars->est_dirs[i*2+1] = SAF_PI/2.0f - pars->est_dirs[i*2+1]; /* convert to inclination */
                     }
                 }
 

--- a/examples/src/dirass/dirass_internal.c
+++ b/examples/src/dirass/dirass_internal.c
@@ -157,8 +157,8 @@ void dirass_initAna(void* const hDir)
         for(j=0; j<N_azi; j++){
             pars->interp_dirs_deg[(i*N_azi + j)*2]   = grid_x_axis[j];
             pars->interp_dirs_deg[(i*N_azi + j)*2+1] = grid_y_axis[i];
-            pars->interp_dirs_rad[(i*N_azi + j)*2] = grid_x_axis[j] * M_PI/180.0f;
-            pars->interp_dirs_rad[(i*N_azi + j)*2+1] = grid_y_axis[i] * M_PI/180.0f;
+            pars->interp_dirs_rad[(i*N_azi + j)*2] = grid_x_axis[j] * SAF_PI/180.0f;
+            pars->interp_dirs_rad[(i*N_azi + j)*2+1] = grid_y_axis[i] * SAF_PI/180.0f;
         }
     }
     free(pars->interp_table);
@@ -182,10 +182,10 @@ void dirass_initAna(void* const hDir)
     pars->Cxyz = realloc1d(pars->Cxyz, pars->grid_nDirs * nSH_order * 3 * sizeof(float));
     pars->Cw = realloc1d(pars->Cw, pars->grid_nDirs * nSH_sec * sizeof(float));
     for(i=0; i<pars->grid_nDirs; i++){
-        beamWeightsVelocityPatternsReal(order_sec, c_n, pars->grid_dirs_deg[i*2]*M_PI/180.0f,
-                                        pars->grid_dirs_deg[i*2+1]*M_PI/180.0f, A_xyz, &(pars->Cxyz[i*nSH_order*3]));
-        rotateAxisCoeffsReal(order_sec, c_n, M_PI/2.0f - pars->grid_dirs_deg[i*2+1]*M_PI/180.0f,
-                             pars->grid_dirs_deg[i*2]*M_PI/180.0f, &(pars->Cw[i*nSH_sec]));
+        beamWeightsVelocityPatternsReal(order_sec, c_n, pars->grid_dirs_deg[i*2]*SAF_PI/180.0f,
+                                        pars->grid_dirs_deg[i*2+1]*SAF_PI/180.0f, A_xyz, &(pars->Cxyz[i*nSH_order*3]));
+        rotateAxisCoeffsReal(order_sec, c_n, SAF_PI/2.0f - pars->grid_dirs_deg[i*2+1]*SAF_PI/180.0f,
+                             pars->grid_dirs_deg[i*2]*SAF_PI/180.0f, &(pars->Cw[i*nSH_sec]));
     }
     free(A_xyz);
     free(c_n);
@@ -199,8 +199,8 @@ void dirass_initAna(void* const hDir)
     }
     pars->w = realloc1d(pars->w, pars->grid_nDirs * nSH_order * sizeof(float));
     for(i=0; i<pars->grid_nDirs; i++){
-        rotateAxisCoeffsReal(order, c_n, M_PI/2.0f - pars->grid_dirs_deg[i*2+1]*M_PI/180.0f,
-                             pars->grid_dirs_deg[i*2]*M_PI/180.0f, &(pars->w[i*nSH_order]));
+        rotateAxisCoeffsReal(order, c_n, SAF_PI/2.0f - pars->grid_dirs_deg[i*2+1]*SAF_PI/180.0f,
+                             pars->grid_dirs_deg[i*2]*SAF_PI/180.0f, &(pars->w[i*nSH_order]));
     }
     free(c_n);
  
@@ -213,8 +213,8 @@ void dirass_initAna(void* const hDir)
     } 
     pars->Uw = realloc1d(pars->Uw, pars->grid_nDirs * nSH_up * sizeof(float));
     for(i=0; i<pars->grid_nDirs; i++){
-        rotateAxisCoeffsReal(order_up, c_n, M_PI/2.0f - pars->grid_dirs_deg[i*2+1]*M_PI/180.0f,
-                             pars->grid_dirs_deg[i*2]*M_PI/180.0f, &(pars->Uw[i*nSH_up]));
+        rotateAxisCoeffsReal(order_up, c_n, SAF_PI/2.0f - pars->grid_dirs_deg[i*2+1]*SAF_PI/180.0f,
+                             pars->grid_dirs_deg[i*2]*SAF_PI/180.0f, &(pars->Uw[i*nSH_up]));
     }
     free(c_n);
  

--- a/examples/src/panner/panner_internal.c
+++ b/examples/src/panner/panner_internal.c
@@ -305,7 +305,7 @@ void panner_loadSourcePreset
     /* Fill remaining slots with default coords */
     for(; ch<MAX_NUM_INPUTS; ch++){
         for(i=0; i<2; i++){
-            dirs_deg[ch][i] = __default_LScoords64_rad[ch][i]* (180.0f/M_PI);
+            dirs_deg[ch][i] = __default_LScoords64_rad[ch][i]* (180.0f/SAF_PI);
         }
     }
     
@@ -504,7 +504,7 @@ void panner_loadLoudspeakerPreset
     /* Fill remaining slots with default coords */
     for(; ch<MAX_NUM_INPUTS; ch++){
         for(i=0; i<2; i++){
-            dirs_deg[ch][i] = __default_LScoords64_rad[ch][i]* (180.0f/M_PI);
+            dirs_deg[ch][i] = __default_LScoords64_rad[ch][i]* (180.0f/SAF_PI);
         }
     }
 

--- a/examples/src/sldoa/sldoa.c
+++ b/examples/src/sldoa/sldoa.c
@@ -83,7 +83,7 @@ void sldoa_create
         pData->secCoeffs[i] = NULL;
     for(i=0; i<64; i++)
         for(j=0; j<NUM_GRID_DIRS; j++)
-            pData->grid_Y[i][j] = (float)__grid_Y[i][j] * sqrtf(4.0*M_PI);
+            pData->grid_Y[i][j] = (float)__grid_Y[i][j] * sqrtf(4.0f*SAF_PI);
     for(i=0; i<3; i++)
         for(j=0; j<NUM_GRID_DIRS; j++)
             pData->grid_Y_dipoles_norm[i][j] = pData->grid_Y[i+1][j]/sqrtf(3); /* scale to [0..1] */
@@ -312,8 +312,8 @@ void sldoa_analysis
                     nSectors = nSectorsPerBand[band];
                     /* store averaged values */
                     for(i=0; i<nSectors; i++){
-                        pData->azi_deg [current_disp_idx][band*MAX_NUM_SECTORS + i] = pData->doa_rad[band][i][0]*180.0f/M_PI;
-                        pData->elev_deg[current_disp_idx][band*MAX_NUM_SECTORS + i] = pData->doa_rad[band][i][1]*180.0f/M_PI;
+                        pData->azi_deg [current_disp_idx][band*MAX_NUM_SECTORS + i] = pData->doa_rad[band][i][0]*180.0f/SAF_PI;
+                        pData->elev_deg[current_disp_idx][band*MAX_NUM_SECTORS + i] = pData->doa_rad[band][i][1]*180.0f/SAF_PI;
 
                         /* colour should indicate the different frequencies */
                         pData->colourScale[current_disp_idx][band*MAX_NUM_SECTORS + i] = (float)(band-min_band)/(float)(numAnalysisBands+1);

--- a/framework/modules/saf_hoa/saf_hoa_internal.c
+++ b/framework/modules/saf_hoa/saf_hoa_internal.c
@@ -148,7 +148,7 @@ void getAllRAD
                 G_td, nLS,
                 Y_td, nDirs_td, 0.0f,
                 decMtx, nSH);
-    cblas_sscal(nLS*nSH, (4.0f*M_PI)/(float)nDirs_td, decMtx, 1);
+    cblas_sscal(nLS*nSH, (4.0f*SAF_PI)/(float)nDirs_td, decMtx, 1);
 
     free(Y_td);
     free(G_td);

--- a/framework/modules/saf_sh/saf_sh.c
+++ b/framework/modules/saf_sh/saf_sh.c
@@ -227,7 +227,7 @@ void getSHreal
         
         /* normalisation */
         for(m=-n, j=0; m<=n; m++, j++)
-            norm_real[j] = sqrt( (2.0*(double)n+1.0) * (double)factorial(n-abs(m)) / (4.0*M_PI*(double)factorial(n+abs(m))) );
+            norm_real[j] = sqrt( (2.0*(double)n+1.0) * (double)factorial(n-abs(m)) / (4.0*SAF_PId*(double)factorial(n+abs(m))) );
         
         /* norm_real * Lnm_real .* CosSin; */
         for(dir=0; dir<nDirs; dir++){
@@ -356,7 +356,7 @@ void getSHcomplex
         
         /* normalisation */
         for(m=0; m<=n; m++)
-            norm_real[m] = sqrt( (2.0*(double)n+1.0)*(double)factorial(n-m) / (4.0*M_PI*(double)factorial(n+m)) );
+            norm_real[m] = sqrt( (2.0*(double)n+1.0)*(double)factorial(n-m) / (4.0*SAF_PId*(double)factorial(n+m)) );
         
         /* norm_real .* Lnm_real .* CosSin; */
         for(dir=0; dir<nDirs; dir++){
@@ -629,7 +629,7 @@ float computeSectorCoeffsEP
                             b_n, 1,
                             b_n, 1, 0.0f,
                             &Q, 1);
-                Q = 4.0f*M_PI/(Q);
+                Q = 4.0f*SAF_PI/(Q);
                 break;
             case SECTOR_PATTERN_CARDIOID:
                 beamWeightsCardioid2Spherical(orderSec, b_n);
@@ -640,9 +640,9 @@ float computeSectorCoeffsEP
         
         for(ns=0; ns<nSecDirs; ns++){
             /* rotate the pattern by rotating the coefficients */
-            azi_sec = sec_dirs_deg[ns*2] * M_PI/180.0f;
-            elev_sec = sec_dirs_deg[ns*2+1] * M_PI/180.0f; /* from elevation to inclination */
-            rotateAxisCoeffsReal(orderSec, b_n, M_PI/2.0f-elev_sec, azi_sec, c_nm);
+            azi_sec = sec_dirs_deg[ns*2] * SAF_PI/180.0f;
+            elev_sec = sec_dirs_deg[ns*2+1] * SAF_PI/180.0f; /* from elevation to inclination */
+            rotateAxisCoeffsReal(orderSec, b_n, SAF_PI/2.0f-elev_sec, azi_sec, c_nm);
             beamWeightsVelocityPatternsReal(orderSec, b_n, azi_sec, elev_sec, A_xyz, xyz_nm);
      
             /* store coefficients */
@@ -693,9 +693,9 @@ float computeSectorCoeffsAP
         
         for(ns=0; ns<nSecDirs; ns++){
             /* rotate the pattern by rotating the coefficients */
-            azi_sec = sec_dirs_deg[ns*2] * M_PI/180.0f;
-            elev_sec = sec_dirs_deg[ns*2+1] * M_PI/180.0f;
-            rotateAxisCoeffsReal(orderSec, b_n, M_PI/2.0f-elev_sec, azi_sec, c_nm);
+            azi_sec = sec_dirs_deg[ns*2] * SAF_PI/180.0f;
+            elev_sec = sec_dirs_deg[ns*2+1] * SAF_PI/180.0f;
+            rotateAxisCoeffsReal(orderSec, b_n, SAF_PI/2.0f-elev_sec, azi_sec, c_nm);
             beamWeightsVelocityPatternsReal(orderSec, b_n, azi_sec, elev_sec, A_xyz, xyz_nm);
             
             /* store coefficients */
@@ -723,7 +723,7 @@ void beamWeightsCardioid2Spherical
     
     /* The coefficients can be derived by the binomial expansion of the cardioid function */
     for(n=0; n<N+1; n++) {
-        b_n[n] = sqrtf(4.0f*M_PI*(2.0f*(float)n+1.0f)) *
+        b_n[n] = sqrtf(4.0f*SAF_PI*(2.0f*(float)n+1.0f)) *
                  (float)factorial(N)* (float)factorial(N+1)/
                  ((float)factorial(N+n+1)*(float)factorial(N-n))/
                  ((float)N+1.0f);
@@ -743,7 +743,7 @@ void beamWeightsHypercardioid2Spherical
     c_n = malloc1d((N+1)*(N+1)*sizeof(float));
     getSHreal(N, dirs_rad, 1, c_n);
     for(n=0; n<N+1; n++)
-        b_n[n] = c_n[(n+1)*(n+1)-n-1] * 4.0f * M_PI/(powf((float)N+1.0f, 2.0f));
+        b_n[n] = c_n[(n+1)*(n+1)-n-1] * 4.0f * SAF_PI/(powf((float)N+1.0f, 2.0f));
     
     free(c_n);
 }
@@ -764,8 +764,8 @@ void beamWeightsMaxEV
     for (n=0; n<=N; n++) {
         temp_i = cos(2.4068f/((double)N+1.51));
         unnorm_legendreP(n, &temp_i, 1, temp_o);
-        b_n[n] = sqrtf((2.0f*(float)n+1.0f)/(4.0f*M_PI))*(float)temp_o[0];
-        norm +=  sqrtf((2.0f*(float)n+1.0f)/(4.0f*M_PI))*b_n[n];
+        b_n[n] = sqrtf((2.0f*(float)n+1.0f)/(4.0f*SAF_PI))*(float)temp_o[0];
+        norm +=  sqrtf((2.0f*(float)n+1.0f)/(4.0f*SAF_PI))*b_n[n];
     }
     
     /* normalise to unity response on look-direction */
@@ -815,7 +815,7 @@ void beamWeightsVelocityPatternsComplex
     c_nm = malloc1d(nSH_l*sizeof(float_complex));
     A_1 = malloc1d(nSH*nSH_l*sizeof(float_complex));
     velCoeffs_T = malloc1d(3*nSH*sizeof(float_complex));
-    rotateAxisCoeffsComplex(order, b_n, M_PI/2.0f-elev_rad, azi_rad, c_nm);
+    rotateAxisCoeffsComplex(order, b_n, SAF_PI/2.0f-elev_rad, azi_rad, c_nm);
     
     /* x_nm, y_nm, z_nm */
     for(d3 = 0; d3<3; d3++){
@@ -876,7 +876,7 @@ void rotateAxisCoeffsComplex
     getSHcomplex(order, (float*)phi_theta, 1, Y_N);
     for(n=0, q = 0; n<=order; n++)
         for(m=-n; m<=n; m++, q++)
-            c_nm[q] = crmulf(conjf(Y_N[q]), sqrtf(4.0f*M_PI/(2.0f*(float)n+1.0f)) * c_n[n]);
+            c_nm[q] = crmulf(conjf(Y_N[q]), sqrtf(4.0f*SAF_PI/(2.0f*(float)n+1.0f)) * c_n[n]);
     
     free(Y_N);
 }
@@ -1933,7 +1933,7 @@ float sphArrayAliasLim
     int maxN
 )
 {
-   return c*(float)maxN/(2.0f*M_PI*r);
+   return c*(float)maxN/(2.0f*SAF_PI*r);
 }
 
 void sphArrayNoiseThreshold
@@ -1958,8 +1958,8 @@ void sphArrayNoiseThreshold
     for (n=1; n<maxN+1; n++){
         b_N = malloc1d((n+1) * sizeof(double_complex));
         sphModalCoeffs(n, &kr, 1, arrayType, dirCoeff, b_N);
-        kR_lim = powf(maxG*(float)Nsensors* powf((float)cabs(b_N[n])/(4.0f*M_PI), 2.0f), (-10.0f*log10f(2.0f)/(6.0f*n)));
-        f_lim[n-1] = kR_lim*c/(2.0f*M_PI*r);
+        kR_lim = powf(maxG*(float)Nsensors* powf((float)cabs(b_N[n])/(4.0f*SAF_PI), 2.0f), (-10.0f*log10f(2.0f)/(6.0f*n)));
+        f_lim[n-1] = kR_lim*c/(2.0f*SAF_PI*r);
         free(b_N);
     }
 }
@@ -1989,7 +1989,7 @@ void sphModalCoeffs
             /* modal coefficients for open spherical array (omni sensors): 4*pi*1i^n * jn; */
             for(n=0; n<maxN+1; n++)
                 for(i=0; i<nBands; i++)
-                    b_N[i*(order+1)+n] = crmul(crmul(cpow(cmplx(0.0,1.0), cmplx((double)n,0.0)), 4.0*M_PI), jn[i*(order+1)+n]);
+                    b_N[i*(order+1)+n] = crmul(crmul(cpow(cmplx(0.0,1.0), cmplx((double)n,0.0)), 4.0*SAF_PId), jn[i*(order+1)+n]);
             
             free(jn);
             break;
@@ -2003,7 +2003,7 @@ void sphModalCoeffs
             /* modal coefficients for open spherical array (directional sensors): 4*pi*1i^n * (dirCoeff*jn - 1i*(1-dirCoeff)*jnprime); */
             for(n=0; n<maxN+1; n++)
                 for(i=0; i<nBands; i++)
-                    b_N[i*(order+1)+n] = ccmul(crmul(cpow(cmplx(0.0,1.0), cmplx((double)n,0.0)), 4.0*M_PI), ccsub(cmplx(dirCoeff*jn[i*(order+1)+n], 0.0),
+                    b_N[i*(order+1)+n] = ccmul(crmul(cpow(cmplx(0.0,1.0), cmplx((double)n,0.0)), 4.0*SAF_PId), ccsub(cmplx(dirCoeff*jn[i*(order+1)+n], 0.0),
                                          cmplx(0.0, (1.0-dirCoeff)*jnprime[i*(order+1)+n]))  );
             
             free(jn);
@@ -2030,11 +2030,11 @@ void sphModalCoeffs
             for(i=0; i<nBands; i++){
                 for(n=0; n<maxN+1; n++){
                     if(n==0 && kr[i]<=1e-20)
-                        b_N[i*(order+1)+n] = cmplx(4.0*M_PI, 0.0);
+                        b_N[i*(order+1)+n] = cmplx(4.0*SAF_PId, 0.0);
                     else if(kr[i] <= 1e-20)
                         b_N[i*(order+1)+n] = cmplx(0.0, 0.0);
                     else{
-                        b_N[i*(order+1)+n] = ccmul(crmul(cpow(cmplx(0.0,1.0), cmplx((double)n,0.0)), 4.0*M_PI), ( ccsub(cmplx(jn[i*(order+1)+n], 0.0),
+                        b_N[i*(order+1)+n] = ccmul(crmul(cpow(cmplx(0.0,1.0), cmplx((double)n,0.0)), 4.0*SAF_PId), ( ccsub(cmplx(jn[i*(order+1)+n], 0.0),
                                              ccmul(ccdiv(cmplx(jnprime[i*(order+1)+n],0.0), hn2prime[i*(order+1)+n]), hn2[i*(order+1)+n]))));
                     }
                 }
@@ -2081,11 +2081,11 @@ void sphScattererModalCoeffs
     for(i=0; i<nBands; i++){
         for(n=0; n<maxN+1; n++){
             if(n==0 && kr[i]<=1e-20)
-                b_N[i*(order+1)+n] = cmplx(4.0*M_PI, 0.0);
+                b_N[i*(order+1)+n] = cmplx(4.0*SAF_PId, 0.0);
             else if(kr[i] <= 1e-20)
                 b_N[i*(order+1)+n] = cmplx(0.0, 0.0);
             else{
-                b_N[i*(order+1)+n] = ccmul(crmul(cpow(cmplx(0.0,1.0), cmplx((double)n,0.0)), 4.0*M_PI), ( ccsub(cmplx(jn[i*(order+1)+n], 0.0),
+                b_N[i*(order+1)+n] = ccmul(crmul(cpow(cmplx(0.0,1.0), cmplx((double)n,0.0)), 4.0*SAF_PId), ( ccsub(cmplx(jn[i*(order+1)+n], 0.0),
                                      ccmul(ccdiv(cmplx(jnprime[i*(order+1)+n],0.0), hn2prime[i*(order+1)+n]), hn2[i*(order+1)+n]))));
             }
         }
@@ -2135,7 +2135,7 @@ void sphScattererDirModalCoeffs
     for(i=0; i<nBands; i++){
         for(n=0; n<maxN+1; n++){
             if(n==0 && kr[i]<=1e-20)
-                b_N[i*(order+1)+n] = cmplx(4.0*M_PI, 0.0);
+                b_N[i*(order+1)+n] = cmplx(4.0*SAF_PId, 0.0);
             else if(kr[i] <= 1e-20)
                 b_N[i*(order+1)+n] = cmplx(0.0, 0.0);
             else{ // Dear god, what happened here?!...
@@ -2147,10 +2147,10 @@ void sphScattererDirModalCoeffs
                 b_N[i*(order+1)+n] = cmplx(dirCoeff * jn_kr[i*(order+1)+n], -(1.0-dirCoeff)* jnprime_kr[i*(order+1)+n]);
                 b_N[i*(order+1)+n] = ccsub(b_N[i*(order+1)+n], ccmul(ccdiv(cmplx(jnprime_kR[i*(order+1)+n], 0.0), hn2prime_kR[i*(order+1)+n]),
                                     (ccsub(crmul(hn2_kr[i*(order+1)+n], dirCoeff), ccmul(cmplx(0.0f,1.0-dirCoeff), hn2prime_kr[i*(order+1)+n])))));
-                b_N[i*(order+1)+n] = crmul(ccmul(cpow(cmplx(0.0,1.0), cmplx((double)n,0.0)), b_N[i*(order+1)+n]), 4.0*M_PI/dirCoeff); /* had to scale by directivity to preserve amplitude? */ 
+                b_N[i*(order+1)+n] = crmul(ccmul(cpow(cmplx(0.0,1.0), cmplx((double)n,0.0)), b_N[i*(order+1)+n]), 4.0*SAF_PId/dirCoeff); /* had to scale by directivity to preserve amplitude? */ 
 //                b_N[i*(order+1)+n] = dirCoeff * jn_kr[i*(order+1)+n] - I*(1.0-dirCoeff)* jnprime_kr[i*(order+1)+n];
 //                b_N[i*(order+1)+n] = b_N[i*(order+1)+n] - (jnprime_kR[i*(order+1)+n]/hn2prime_kR[i*(order+1)+n])*(dirCoeff*hn2_kr[i*(order+1)+n] - I*(1.0-dirCoeff)*hn2prime_kr[i*(order+1)+n]);
-//                b_N[i*(order+1)+n] = cpow(cmplx(0.0,1.0), cmplx((double)n,0.0)) * b_N[i*(order+1)+n] * 4.0*M_PI/dirCoeff; /* had to scale by directivity to preserve amplitude? */
+//                b_N[i*(order+1)+n] = cpow(cmplx(0.0,1.0), cmplx((double)n,0.0)) * b_N[i*(order+1)+n] * 4.0*SAF_PId/dirCoeff; /* had to scale by directivity to preserve amplitude? */
 //#endif
             }
         }
@@ -2204,7 +2204,7 @@ void sphDiffCohMtxTheory
             break;
     }
     for(i=0; i<nBands * (order+1); i++)
-        b_N2[i] = pow(cabs(ccdiv(b_N[i], cmplx(4.0*M_PI, 0.0))), 2.0);
+        b_N2[i] = pow(cabs(ccdiv(b_N[i], cmplx(4.0*SAF_PId, 0.0))), 2.0);
     
     /* determine theoretical diffuse-coherence matrix for sensor array */
     ppm = malloc1d((order+1)*sizeof(float));
@@ -2219,7 +2219,7 @@ void sphDiffCohMtxTheory
             cosangle = cosangle>1.0f ? 1.0f : (cosangle<-1.0f ? -1.0f : cosangle);
             for(n=0; n<order+1; n++){
                 unnorm_legendreP_recur(n, &cosangle, 1, ppm_z1, ppm_z2, ppm);  
-                Pn[n] =  (2.0*(double)n+1.0) * 4.0f*M_PI * (double)ppm[0];
+                Pn[n] =  (2.0*(double)n+1.0) * 4.0f*SAF_PI * (double)ppm[0];
                 memcpy(ppm_z2, ppm_z1, (order+1)*sizeof(float));
                 memcpy(ppm_z1, ppm, (order+1)*sizeof(float));
             }
@@ -2268,7 +2268,7 @@ void simulateCylArray /*untested*/
     b_NC = malloc1d(nBands*N_sensors*sizeof(double_complex));
     for(i=0; i<N_srcs; i++){
         for(j=0; j<N_sensors; j++){
-            angle = sensor_dirs_rad[i*2] - src_dirs_deg[i*2]*M_PI/180.0;
+            angle = sensor_dirs_rad[i*2] - src_dirs_deg[i*2]*SAF_PId/180.0;
             for(n=0; n<order+1; n++){
                 /* Jacobi-Anger expansion */
                 if(n==0)
@@ -2349,7 +2349,7 @@ void simulateSphArray
                 /* Legendre polynomials correspond to the angular dependency */
                 dcosangle = (double)cosangle;
                 unnorm_legendreP(n, &dcosangle, 1, ppm);
-                P[n*N_sensors+j] = cmplx((2.0*(double)n+1.0)/(4.0*M_PI) * ppm[0], 0.0);
+                P[n*N_sensors+j] = cmplx((2.0*(double)n+1.0)/(4.0*SAF_PId) * ppm[0], 0.0);
             }
         }
         cblas_zgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, nBands, N_sensors, order+1, &calpha,

--- a/framework/modules/saf_sh/saf_sh_internal.c
+++ b/framework/modules/saf_sh/saf_sh_internal.c
@@ -130,7 +130,7 @@ void gaunt_mtx
                                 wigner3jm = wigner_3j(n1, n2, n, m1, m2, -m);
                                 wigner3j0 = wigner_3j(n1, n2, n, 0, 0, 0);
                                 A[q1*D2*D3 + q2*D3 + q] = powf(-1.0f,(float)m) *
-                                                          sqrtf((2.0f*(float)n1+1.0f)*(2.0f*(float)n2+1.0f)*(2.0f*(float)n+1.0f)/(4.0f*M_PI)) *
+                                                          sqrtf((2.0f*(float)n1+1.0f)*(2.0f*(float)n2+1.0f)*(2.0f*(float)n+1.0f)/(4.0f*SAF_PI)) *
                                                           wigner3jm * wigner3j0;
                             }
                         }

--- a/framework/modules/saf_sofa_reader/libmysofa/internal/mysofa_internal.c
+++ b/framework/modules/saf_sofa_reader/libmysofa/internal/mysofa_internal.c
@@ -871,15 +871,15 @@ MYSOFA_EXPORT void mysofa_c2s(float values[3]) {
   theta = atan2f(z, sqrtf(x * x + y * y));
   phi = atan2f(y, x);
 
-  values[0] = fmodf(phi * (180 / M_PI) + 360, 360);
-  values[1] = theta * (180 / M_PI);
+  values[0] = fmodf(phi * (180.0 / SAF_PId) + 360, 360);
+  values[1] = theta * (180.0 / SAF_PId);
   values[2] = r;
 }
 
 MYSOFA_EXPORT void mysofa_s2c(float values[3]) {
   float x, r, theta, phi;
-  phi = values[0] * (M_PI / 180);
-  theta = values[1] * (M_PI / 180);
+  phi = values[0] * (SAF_PId / 180.0);
+  theta = values[1] * (SAF_PId / 180.0);
   r = values[2];
   x = cosf(theta) * r;
   values[2] = sinf(theta) * r;

--- a/framework/modules/saf_utilities/saf_utilities.h
+++ b/framework/modules/saf_utilities/saf_utilities.h
@@ -66,16 +66,6 @@
 /** Boolean false */
 #define SAF_FALSE ( 0 )
 
-#ifndef M_PI
-/** pi constant (single precision) */
-# define M_PI ( 3.14159265358979323846264338327950288f )
-#endif
-
-#ifndef M_PId
-/** pi constant (double precision) */
-# define M_PId ( 3.14159265358979323846264338327950288 )
-#endif
-
 /** pi constant (single precision) */
 # define SAF_PI ( 3.14159265358979323846264338327950288f )
 

--- a/framework/modules/saf_utilities/saf_utility_filters.c
+++ b/framework/modules/saf_utilities/saf_utility_filters.c
@@ -56,7 +56,7 @@ static void applyWindowingFunction
             for(i=0; i<winlength; i++)
                 x[i] *= 0.54f - 0.46f * (cosf(2.0f*SAF_PI*(float)i/(float)N)); /* more wide-spread coefficient values */
             /* optimal equiripple coefficient values: */
-            /*x[i] *= 0.53836f - 0.46164f * (cosf(2.0f*M_PI*(float)i/(float)N));*/
+            /*x[i] *= 0.53836f - 0.46164f * (cosf(2.0f*SAF_PI*(float)i/(float)N));*/
             break;
             
         case WINDOWING_FUNCTION_HANN:

--- a/framework/modules/saf_utilities/saf_utility_pitch.c
+++ b/framework/modules/saf_utilities/saf_utility_pitch.c
@@ -70,7 +70,7 @@ static void smbFft(float *fftBuffer, int fftFrameSize, long sign)
         le2 = le>>1;
         ur = 1.0;
         ui = 0.0;
-        arg = M_PI / (le2>>1);
+        arg = SAF_PI / (le2>>1);
         wr = cos(arg);
         wi = sign*sin(arg);
         for (j = 0; j < le2; j += 2) {

--- a/test/src/test__examples.c
+++ b/test/src/test__examples.c
@@ -380,9 +380,9 @@ void test__saf_example_rotator(void){
     /* Configure rotator codec */
     rotator_setOrder(hRot, (SH_ORDERS)order);
     rotator_setNormType(hRot, NORM_N3D);
-    rotator_setYaw(hRot, ypr[0]*180.0f/M_PI); /* rad->degrees */
-    rotator_setPitch(hRot, ypr[1]*180.0f/M_PI);
-    rotator_setRoll(hRot, ypr[2]*180.0f/M_PI);
+    rotator_setYaw(hRot, ypr[0]*180.0f/SAF_PI); /* rad->degrees */
+    rotator_setPitch(hRot, ypr[1]*180.0f/SAF_PI);
+    rotator_setRoll(hRot, ypr[2]*180.0f/SAF_PI);
 
     /* Define input mono signal */
     nSH = ORDER2NSH(order);

--- a/test/src/test__hoa_module.c
+++ b/test/src/test__hoa_module.c
@@ -44,8 +44,8 @@ void test__getLoudspeakerDecoderMtx(void){
         nLS = __Tdesign_nPoints_per_degree[2 * order-1];
         ls_dirs_rad = (float**)malloc2d(nLS, 2, sizeof(float));
         for(j=0; j<nLS; j++){
-            ls_dirs_rad[j][0] = ls_dirs_deg[j*2] * M_PI/180.0f;
-            ls_dirs_rad[j][1] = M_PI/2.0f - ls_dirs_deg[j*2+1] * M_PI/180.0f; /* elevation->inclination */
+            ls_dirs_rad[j][0] = ls_dirs_deg[j*2] * SAF_PI/180.0f;
+            ls_dirs_rad[j][1] = SAF_PI/2.0f - ls_dirs_deg[j*2+1] * SAF_PI/180.0f; /* elevation->inclination */
         }
 
         /* Compute decoders */

--- a/test/src/test__sh_module.c
+++ b/test/src/test__sh_module.c
@@ -45,8 +45,8 @@ void test__getSHreal(void){
         nDirs = __Tdesign_nPoints_per_degree[2*order];
         t_dirs_rad = (float**)malloc2d(nDirs, 2, sizeof(float));
         for(j=0; j<nDirs; j++){
-            t_dirs_rad[j][0] = t_dirs_deg[j*2] * M_PI/180.0f;
-            t_dirs_rad[j][1] = M_PI/2.0f - t_dirs_deg[j*2+1] * M_PI/180.0f; /* elevation->inclination */
+            t_dirs_rad[j][0] = t_dirs_deg[j*2] * SAF_PI/180.0f;
+            t_dirs_rad[j][1] = SAF_PI/2.0f - t_dirs_deg[j*2+1] * SAF_PI/180.0f; /* elevation->inclination */
         }
 
         /* Compute spherical harmonic coefficients */
@@ -99,8 +99,8 @@ void test__getSHreal_recur(void){
     for(i=0; i<1e3; i++){
         rand_m1_1(&dir[0] , 1);
         rand_m1_1(&dir[1] , 1);
-        dir[0] *= M_PI;
-        dir[1] *= M_PI/2.0f;
+        dir[0] *= SAF_PI;
+        dir[1] *= SAF_PI/2.0f;
         getSHreal_recur(order, (float*)dir, 1, (float*)Yr);
         getSHreal(order, (float*)dir, 1, (float*)Y);
         for(j=0; j<nSH; j++)
@@ -131,8 +131,8 @@ void test__getSHcomplex(void){
         nDirs = __Tdesign_nPoints_per_degree[2*order];
         t_dirs_rad = (float**)malloc2d(nDirs, 2, sizeof(float));
         for(j=0; j<nDirs; j++){
-            t_dirs_rad[j][0] = t_dirs_deg[j*2] * M_PI/180.0f;
-            t_dirs_rad[j][1] = M_PI/2.0f - t_dirs_deg[j*2+1] * M_PI/180.0f; /* elevation->inclination */
+            t_dirs_rad[j][0] = t_dirs_deg[j*2] * SAF_PI/180.0f;
+            t_dirs_rad[j][1] = SAF_PI/2.0f - t_dirs_deg[j*2+1] * SAF_PI/180.0f; /* elevation->inclination */
         }
 
         /* Compute spherical harmonic coefficients */
@@ -257,8 +257,8 @@ void test__real2complexSHMtx(void){
             /* Random direction */
             rand_m1_1(&dir[0] , 1);
             rand_m1_1(&dir[1] , 1);
-            dir[0] *= M_PI;
-            dir[1] *= M_PI/2.0f;
+            dir[0] *= SAF_PI;
+            dir[1] *= SAF_PI/2.0f;
 
             /* Compute reference spherical harmonic weights */
             getSHcomplex(order, (float*)dir, 1, Y_complex_ref);
@@ -317,8 +317,8 @@ void test__complex2realSHMtx(void){
             /* Random direction */
             rand_m1_1(&dir[0] , 1);
             rand_m1_1(&dir[1] , 1);
-            dir[0] *= M_PI;
-            dir[1] *= M_PI/2.0f;
+            dir[0] *= SAF_PI;
+            dir[1] *= SAF_PI/2.0f;
 
             /* Compute reference spherical harmonic weights */
             getSHcomplex(order, (float*)dir, 1, Y_complex_ref);
@@ -406,8 +406,8 @@ void test__checkCondNumberSHTReal(void){
         nDirs = __Tdesign_nPoints_per_degree[2 * order];
         t_dirs_rad = (float **) malloc2d(nDirs, 2, sizeof(float));
         for (j = 0; j < nDirs; j++) {
-            t_dirs_rad[j][0] = t_dirs_deg[j * 2] * M_PI / 180.0f;
-            t_dirs_rad[j][1] = M_PI / 2.0f - t_dirs_deg[j * 2 + 1] * M_PI /
+            t_dirs_rad[j][0] = t_dirs_deg[j * 2] * SAF_PI / 180.0f;
+            t_dirs_rad[j][1] = SAF_PI / 2.0f - t_dirs_deg[j * 2 + 1] * SAF_PI /
                                              180.0f; /* elevation->inclination */
         }
 
@@ -656,8 +656,8 @@ void test__sphESPRIT(void){
     sphESPRIT_create(&hESPRIT, order);
     sphESPRIT_estimateDirs(hESPRIT, FLATTEN2D(Us), nSrcs, (float*)estdirs_deg);
     for(i=0; i<nSrcs; i++){
-        estdirs_deg[i][0]*=180.0f/M_PI; /* rad->deg */
-        estdirs_deg[i][1]*=180.0f/M_PI;
+        estdirs_deg[i][0]*=180.0f/SAF_PI; /* rad->deg */
+        estdirs_deg[i][1]*=180.0f/SAF_PI;
     }
 
     /* Assert that the true source directions were found (note that the order can flip) */

--- a/test/src/test__utilities_module.c
+++ b/test/src/test__utilities_module.c
@@ -463,7 +463,7 @@ void test__smb_pitchShifter(void){
     outputData = calloc1d(nSamples,sizeof(float));
     frequency = (float)sampleRate/8.0f;
     for(i=0; i<nSamples; i++) /* sine tone at quarter Nyquist: */
-        inputData[i] = sinf(2.0f * M_PI * (float)i * frequency/(float)sampleRate);
+        inputData[i] = sinf(2.0f * SAF_PI * (float)i * frequency/(float)sampleRate);
     smbLatency = FFTsize - (FFTsize/osfactor);
 
     /* Pitch shift down one octave */


### PR DESCRIPTION
## What is the goal of this PR?

Fix warnings in code that already defines `M_PI` as a double.

## What are the changes implemented in this PR?

`M_PI` is a very common define and usually defined as a `double`. In `framework/modules/saf_utilities/saf_utilities.h`, however, it is defined as a `float`, unless previously defined otherwise. Using this in code that defines e.g. `_USE_MATH_DEFINES` leads to a lot of warnings, as the Spatial_Audio_Framework code expects `M_PI` to be `float` but it is indeed a `double`.

This PR just removes the use of the `M_PI` macro entirely (except in external speex_resampler) and uses the corresponding `SAF_PI` and `SAF_PId` macros, instead.

Closes #37.