### PR TITLE
Fix some memory leaks and a missing initialization

### DIFF
--- a/examples/src/ambi_bin/ambi_bin.c
+++ b/examples/src/ambi_bin/ambi_bin.c
@@ -79,6 +79,7 @@ void ambi_bin_create
     pData->nSH =  (pData->order+1)*(pData->order+1);
     
     /* afSTFT and audio buffers */
+    pData->fs = 0;
     pData->hSTFT = NULL;
     pData->SHFrameTD = (float**)malloc2d(MAX_NUM_SH_SIGNALS, AMBI_BIN_FRAME_SIZE, sizeof(float));
     pData->binFrameTD = (float**)malloc2d(NUM_EARS, AMBI_BIN_FRAME_SIZE, sizeof(float));
@@ -128,6 +129,7 @@ void ambi_bin_destroy
         free(pData->binframeTF);
 
         pars = pData->pars;
+        free(pars->sofa_filepath);
         free(pars->weights);
         free(pars->hrtf_fb);
         free(pars->itds_s);

--- a/framework/modules/saf_utilities/saf_utility_geometry.c
+++ b/framework/modules/saf_utilities/saf_utility_geometry.c
@@ -825,6 +825,7 @@ void sphVoronoi
     }
 
     /* clean-up */
+    free(duplicates);
     free(faceIdx);
     free(sorted);
     free(tempfacelist);
@@ -893,6 +894,8 @@ void sphVoronoiAreas
             tmp += theta[i];
         areas[m] = tmp - ((float)N_poly-2.0f)*SAF_PI; 
     }
+    free(face);
+    free(theta);
 }
 
 void getVoronoiWeights
@@ -936,6 +939,7 @@ void getVoronoiWeights
     free(areas);
     for(i=0; i<voronoi.nFaces; i++)
         free(voronoi.faces[i]);
+    free(voronoi.faces);
     free(voronoi.vert);
     free(voronoi.nPointsPerFace);
 }


### PR DESCRIPTION
Some small fixes discovered while doing some memory investigation.

* Initialize pData->fs so it won't cause issues in the future (it does strictly speaking not cause issues today, but in `ambi_bin_init` it is used in a comparison while uninitialized, which might cause hard to debug issues when other code changes)

* Add some missing calls to `free`, fixing memory leaks

