### PR TITLE
Fix sofa_filepath memory issues and another memory leak in vbap

### DIFF
--- a/examples/src/ambi_bin/ambi_bin.c
+++ b/examples/src/ambi_bin/ambi_bin.c
@@ -504,7 +504,7 @@ void ambi_bin_setSofaFilePath(void* const hAmbi, const char* path)
     ambi_bin_data *pData = (ambi_bin_data*)(hAmbi);
     ambi_bin_codecPars* pars = pData->pars;
     
-    pars->sofa_filepath = malloc1d(strlen(path) + 1);
+    pars->sofa_filepath = realloc1d(pars->sofa_filepath, strlen(path) + 1);
     strcpy(pars->sofa_filepath, path);
     pData->useDefaultHRIRsFLAG = 0;
     ambi_bin_refreshParams(hAmbi);  // re-init and re-calc

--- a/examples/src/ambi_dec/ambi_dec.c
+++ b/examples/src/ambi_dec/ambi_dec.c
@@ -147,6 +147,7 @@ void ambi_dec_destroy
         free(pars->hrtf_fb);
         free(pars->hrtf_fb_mag);
         free(pars->itds_s);
+	free(pars->sofa_filepath);
         free(pars->hrirs);
         free(pars->hrir_dirs_deg);
         free(pars->weights);
@@ -681,7 +682,7 @@ void ambi_dec_setSofaFilePath(void* const hAmbi, const char* path)
     ambi_dec_data *pData = (ambi_dec_data*)(hAmbi);
     ambi_dec_codecPars* pars = pData->pars;
     
-    pars->sofa_filepath = malloc1d(strlen(path) + 1);
+    pars->sofa_filepath = realloc1d(pars->sofa_filepath, strlen(path) + 1);
     strcpy(pars->sofa_filepath, path);
     pData->useDefaultHRIRsFLAG = 0;
     ambi_dec_refreshSettings(hAmbi);  // re-init and re-calc

--- a/examples/src/binauraliser/binauraliser.c
+++ b/examples/src/binauraliser/binauraliser.c
@@ -121,6 +121,7 @@ void binauraliser_destroy
         free(pData->hrtf_fb);
         free(pData->hrtf_fb_mag);
         free(pData->itds_s);
+        free(pData->sofa_filepath);
         free(pData->hrirs);
         free(pData->hrir_dirs_deg);
         free(pData->weights);
@@ -343,7 +344,7 @@ void binauraliser_setSofaFilePath(void* const hBin, const char* path)
 {
     binauraliser_data *pData = (binauraliser_data*)(hBin);
     
-    pData->sofa_filepath = malloc1d(strlen(path) + 1);
+    pData->sofa_filepath = realloc1d(pData->sofa_filepath, strlen(path) + 1);
     strcpy(pData->sofa_filepath, path);
     pData->useDefaultHRIRsFLAG = 0;
     binauraliser_refreshSettings(hBin);  // re-init and re-calc

--- a/examples/src/spreader/spreader.c
+++ b/examples/src/spreader/spreader.c
@@ -120,6 +120,8 @@ void spreader_destroy
                pData->procStatus == PROC_STATUS_ONGOING){
             SAF_SLEEP(10);
         }
+
+	free(pData->sofa_filepath);
         
         /* free afSTFT and buffers */
         if(pData->hSTFT !=NULL)
@@ -740,7 +742,7 @@ void spreader_setSofaFilePath(void* const hSpr, const char* path)
 {
     spreader_data *pData = (spreader_data*)(hSpr);
     
-    pData->sofa_filepath = malloc1d(strlen(path) + 1);
+    pData->sofa_filepath = realloc1d(pData->sofa_filepath, strlen(path) + 1);
     strcpy(pData->sofa_filepath, path);
     pData->useDefaultHRIRsFLAG = 0;
     spreader_refreshSettings(hSpr);  // re-init and re-calc

--- a/framework/modules/saf_vbap/saf_vbap.c
+++ b/framework/modules/saf_vbap/saf_vbap.c
@@ -304,6 +304,7 @@ void generateVBAPgainTable3D
     free(out_vertices);
     free(out_faces);
     free(layoutInvMtx);
+    free(src_dirs);
     free(azi);
     free(ele);
 }


### PR DESCRIPTION
From @leomccormack's [comment](https://github.com/leomccormack/Spatial_Audio_Framework/pull/39#issuecomment-1036285551) on my last PR, I added the missing calls to free for sofa_filepath in the other examples, as well as changing the malloc to a realloc.

Also fixed a memory leak in vbap.
