### PR TITLE
binauraliser-dvf: fix preset loading bug

### DIFF
--- a/examples/src/binauraliser_nf/binauraliser_nf.c
+++ b/examples/src/binauraliser_nf/binauraliser_nf.c
@@ -368,8 +368,8 @@ void binauraliserNF_setInputConfigPreset(void* const hBin, int newPresetID)
 
     binauraliser_loadPreset(newPresetID, pData->src_dirs_deg, &(pData->new_nSources), &nDim);
     // For now, any preset selected will reset sources to the far field
-    binauraliserNF_resetSourceDistances(&pData);
-
+    binauraliserNF_resetSourceDistances(pData);
+    
     if(pData->nSources != pData->new_nSources)
         binauraliser_setCodecStatus(hBin, CODEC_STATUS_NOT_INITIALISED);
     for(ch=0; ch<MAX_NUM_INPUTS; ch++)

--- a/framework/modules/saf_utilities/saf_utility_dvf.c
+++ b/framework/modules/saf_utilities/saf_utility_dvf.c
@@ -206,7 +206,7 @@ void convertFrontalDoAToIpsilateral
 {
     float thetaL;
     
-    // TODO: clamp thetaFront (-180, 180)
+    thetaFront = SAF_CLAMP(thetaFront, -180.f, 180.f);
     thetaL = fabsf(90.f - thetaFront);
     if (thetaL > 180.f) {
         thetaL = 360.f - thetaL;

--- a/framework/modules/saf_utilities/saf_utility_dvf.c
+++ b/framework/modules/saf_utilities/saf_utility_dvf.c
@@ -121,13 +121,13 @@ void interpHighShelfParams
     float gInf_1, gInf_2;   /* high shelf gain at inf */
     float fc_1, fc_2;       /* high shelf cutoff frequency */
     
-    // TODO: range checking - clip theta and rho to valid range
+    // TBD: add range checking? - clip theta and rho to valid range
+    
     /* linearly interpolate DC gain, HF gain, center freq at theta */
-    // TODO: rethink this indexing logic...
     thetaDiv10 = theta / 10.f;
     theta_idx_lower = (int)thetaDiv10;      /* Table is in 10 degree steps, floor(x/10) gets lower index */
     theta_idx_upper = theta_idx_lower + 1;
-    if(theta_idx_upper == numAz_table) {    // TODO: if instead check theta_idx_upper => numAz_table, could clip the value > 180 here
+    if(theta_idx_upper == numAz_table) {    // alternatively, instead check theta_idx_upper => numAz_table, could clip the value > 180 here
         theta_idx_upper = theta_idx_lower;
         theta_idx_lower = theta_idx_lower - 1;
     }
@@ -166,8 +166,8 @@ void calcIIRCoeffs
     float va_c;
     
     v0     = db2mag(gInf);              /* Eq. (12), (10), and (11) */
-    g0_mag = db2mag(g0);                // TODO: revisit; does g0, gInf need to be in dB?
-    tanF   = tanf((headDim / fs) * fc); // TODO: this /fs calc can be optimized out with precomputed head dimension
+    g0_mag = db2mag(g0);                // optim TBD: revisit; does g0, gInf need to be in dB?
+    tanF   = tanf((headDim / fs) * fc); // optim TBD: this /fs calc can be optimized out with precomputed head dimension
     v0tanF = v0 * tanF;
     a_c    = (v0tanF - 1.f) / (v0tanF + 1.f);
     

--- a/test/src/test__utilities_module.c
+++ b/test/src/test__utilities_module.c
@@ -1074,7 +1074,7 @@ void test__dvf_interpHighShelfParams(void){
      first on the calcHighShelfParams(), so that should be tested first. */
 
     /* setup */
-    const float acceptedTolerance = 0.0001f;  // TODO: revisit these thresholds
+    const float acceptedTolerance = 0.0001f;
     const float acceptedTolerance_frq = 0.01f;
     const int   nTheta = 6;
     const float theta[6] = {0.000000f,2.300000f,47.614000f,98.600000f,166.200000f,180.000000f};
@@ -1117,7 +1117,7 @@ void test__dvf_interpHighShelfParams(void){
 
 void test__dvf_calcIIRCoeffs(void){
     /* setup */
-    const float acceptedTolerance = 0.00001f; // TODO: revisit these thresholds
+    const float acceptedTolerance = 0.00001f;
     const int   nTheta = 6;
     const float theta[6] = {0.000000f,2.300000f,47.614000f,98.600000f,166.200000f,180.000000f};
     const int   nRho = 5;


### PR DESCRIPTION
Please replace every line in curly brackets ( { like this } ) with an appropriate description, and remove this line.

## What is the goal of this PR?

A bug fix found when trying to load presets.
While I was at it I cleaned up some comments and clamped input to `convertFrontalDoAToIpsilateral` to a valid range.
