### PR TITLE
automatically add compilation flags when activating SIMD support option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The framework can be configured further, with the following options:
 ```
 SAF_USE_INTEL_IPP # To use Intel IPP for performing the DFT/FFT and resampling
 SAF_USE_FFTW      # To use the FFTW library for performing the DFT/FFT 
-SAF_ENABLE_SIMD   # To enable SIMD (SSE, AVX, AVX512) intrinsics for certain vector operations
+SAF_ENABLE_SIMD   # To enable SIMD (SSE3, AVX2 and/or AVX512) intrinsics for certain vector operations
 ```
 
 # Using the framework
@@ -97,7 +97,7 @@ The available SAF-related CMake options (and their default values) are:
 -DSAF_BUILD_EXTRAS=0                         # build safmex etc.
 -DSAF_BUILD_TESTS=1                          # build unit testing program
 -DSAF_USE_INTEL_IPP=0                        # link and use Intel IPP for the FFT, resampler, etc.
--DSAF_ENABLE_SIMD=0                          # enable/disable SSE, AVX, and/or AVX-512 support
+-DSAF_ENABLE_SIMD=0                          # enable/disable SSE3, AVX2, and/or AVX-512 support
 -DSAF_ENABLE_NETCDF=0                        # enable the use of NetCDF (requires external libs)
 -DSAF_ENABLE_FAST_MATH_FLAG=1                # enable the -ffast-math compiler flag on clang/gcc
 ```
@@ -113,8 +113,8 @@ For Linux/MacOS users: the framework, examples, and unit testing program may be 
 ```
 # By default:
 cmake -S . -B build 
-# Or to also enable e.g. SSE3 and AVX2 intrinsics (for both C and C++ code):
-cmake -S . -B build -DSAF_ENABLE_SIMD=1 -DCMAKE_C_FLAGS="-msse3 -mavx2"
+# Or to also enable e.g. SSE3, AVX2, and/or AVX-512 intrinsics (for both C and C++ code):
+cmake -S . -B build -DSAF_ENABLE_SIMD=1
 # Or to build Universal binaries for macOS (ARM/x86), which must therefore use Apple Accelerate:
 cmake -S . -B build -DSAF_PERFORMANCE_LIB=SAF_USE_APPLE_ACCELERATE -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
 # Then to build and run the unit testing program:

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -38,6 +38,12 @@ message("
 
 # Configure SAF
 message(STATUS "Configuring the Spatial_Audio_Framework (SAF):")
+
+if(SAF_ENABLE_SIMD) # before declaring project, set compilation flags for SIMD support
+    set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS}   -march=native" CACHE STRING "Default C options"   FORCE)
+    set(CMAKE_C_FLAGS   "${CMAKE_CXX_FLAGS} -march=native" CACHE STRING "Default CXX options" FORCE)
+endif()
+
 project(saf VERSION ${SAF_VERSION} LANGUAGES C)
 add_library(${PROJECT_NAME}) #STATIC
 set_target_properties(${PROJECT_NAME}
@@ -239,9 +245,7 @@ endif()
 ############################################################################
 # Enable SIMD intrinsics
 if(SAF_ENABLE_SIMD)
-    # Note that you need to pass the appropriate compiler flags to actually
-    # enable certain intrinsics, for example:
-    # $ cmake -S . -B build -DCMAKE_CXX_FLAGS="-msse3 -mavx2" -DCMAKE_C_FLAGS="-msse3 -mavx2"
+    # Note: appropriate compiler flags were previously added before declaration of project 
     message(STATUS "SIMD intrinsics support is enabled.")
     target_compile_definitions(${PROJECT_NAME} PUBLIC SAF_ENABLE_SIMD=1)
 endif()


### PR DESCRIPTION
## What is the goal of this PR?

Using the cmake SAF_ENABLE_SIMD option requires extra compilation flags; this PR propose a method to add them automagically.

## What are the changes implemented in this PR?

If the SAF_ENABLE_SIMD option is enabled, appropriate compilation flags are added prior to the project declaration (or else the extra compilation flags won't be used). 

There's also small changes to the documentation.