### PR TITLE
Fix type conversions

### DIFF
--- a/examples/include/ambi_bin.h
+++ b/examples/include/ambi_bin.h
@@ -207,7 +207,7 @@ void ambi_bin_initCodec(void* const hAmbi);
  */
 void ambi_bin_process(void* const hAmbi,
                       const float *const * inputs,
-                      float** const outputs,
+                      float* const* const outputs,
                       int nInputs,
                       int nOutputs,
                       int nSamples);

--- a/examples/include/ambi_dec.h
+++ b/examples/include/ambi_dec.h
@@ -160,7 +160,7 @@ void ambi_dec_initCodec(void* const hAmbi);
  */
 void ambi_dec_process(void* const hAmbi,
                       const float *const * inputs,
-                      float** const outputs,
+                      float* const* outputs,
                       int nInputs,
                       int nOutputs,
                       int nSamples);

--- a/examples/include/ambi_drc.h
+++ b/examples/include/ambi_drc.h
@@ -130,7 +130,7 @@ void ambi_drc_init(void* const hAmbi,
  */
 void ambi_drc_process(void* const hAmbi,
                       const float *const * inputs,
-                      float** const outputs,
+                      float* const* outputs,
                       int nCH,
                       int nSamples);
 

--- a/examples/include/ambi_enc.h
+++ b/examples/include/ambi_enc.h
@@ -83,7 +83,7 @@ void ambi_enc_init(void* const hAmbi,
  */
 void ambi_enc_process(void* const hAmbi,
                       const float *const * inputs,
-                      float** const outputs,
+                      float* const* outputs,
                       int nInputs,
                       int nOutputs,
                       int nSamples);

--- a/examples/include/ambi_roomsim.h
+++ b/examples/include/ambi_roomsim.h
@@ -86,7 +86,7 @@ void ambi_roomsim_init(void* const hAmbi,
  */
 void ambi_roomsim_process(void* const hAmbi,
                           const float *const * inputs,
-                          float** const outputs,
+                          float* const* outputs,
                           int nInputs,
                           int nOutputs,
                           int nSamples);

--- a/examples/include/array2sh.h
+++ b/examples/include/array2sh.h
@@ -272,7 +272,7 @@ void array2sh_evalEncoder(void* const hA2sh);
  */
 void array2sh_process(void* const hA2sh,
                       const float *const * inputs,
-                      float** const outputs,
+                      float* const* outputs,
                       int nInputs,
                       int nOutputs,
                       int nSamples);

--- a/examples/include/beamformer.h
+++ b/examples/include/beamformer.h
@@ -83,7 +83,7 @@ void beamformer_init(void* const hBeam,
  */
 void beamformer_process(void* const hBeam,
                         const float *const * inputs,
-                        float** const outputs,
+                        float* const* outputs,
                         int nInputs,
                         int nOutputs,
                         int nSamples);

--- a/examples/include/binauraliser.h
+++ b/examples/include/binauraliser.h
@@ -119,7 +119,7 @@ void binauraliser_initCodec(void* const hBin);
  */
 void binauraliser_process(void* const hBin,
                           const float *const * inputs,
-                          float** const outputs,
+                          float* const* outputs,
                           int nInputs,
                           int nOutputs,
                           int nSamples);

--- a/examples/include/binauraliser_nf.h
+++ b/examples/include/binauraliser_nf.h
@@ -123,7 +123,7 @@ void binauraliserNF_initCodec(void* const hBin);
  */
 void binauraliserNF_process(void* const hBin,
                             const float *const * inputs,
-                            float** const outputs,
+                            float* const* outputs,
                             int nInputs,
                             int nOutputs,
                             int nSamples);
@@ -134,7 +134,7 @@ void binauraliserNF_process(void* const hBin,
  */
 void binauraliserNF_processFD(void* const hBin,
                           const float *const * inputs,
-                          float** const outputs,
+                          float* const* outputs,
                           int nInputs,
                           int nOutputs,
                           int nSamples);

--- a/examples/include/decorrelator.h
+++ b/examples/include/decorrelator.h
@@ -100,7 +100,7 @@ void decorrelator_initCodec(void* const hDecor);
  */
 void decorrelator_process(void* const hDecor,
                           const float *const * inputs,
-                          float** const outputs,
+                          float* const* outputs,
                           int nInputs,
                           int nOutputs,
                           int nSamples);

--- a/examples/include/matrixconv.h
+++ b/examples/include/matrixconv.h
@@ -82,7 +82,7 @@ void matrixconv_init(void* const hMCnv,
  */
 void matrixconv_process(void* const hMCnv,
                         const float *const * inputs,
-                        float** const outputs,
+                        float* const* const outputs,
                         int nInputs,
                         int nOutputs,
                         int nSamples);
@@ -122,7 +122,7 @@ void matrixconv_checkReInit(void* const hMCnv);
  * @param[in] sampleRate  Samplerate of the loaded data
  */
 void matrixconv_setFilters(void* const hMCnv,
-                           const float** H,
+                           const float* const* H,
                            int numChannels,
                            int numSamples,
                            int sampleRate);

--- a/examples/include/multiconv.h
+++ b/examples/include/multiconv.h
@@ -82,7 +82,7 @@ void multiconv_init(void* const hMCnv,
  */
 void multiconv_process(void* const hMCnv,
                        const float *const * inputs,
-                       float** const outputs,
+                       float* const* const outputs,
                        int nInputs,
                        int nOutputs,
                        int nSamples);
@@ -115,7 +115,7 @@ void multiconv_checkReInit(void* const hMCnv);
  * @param[in] sampleRate  Samplerate of the loaded data
  */
 void multiconv_setFilters(void* const hMCnv,
-                          const float** H,
+                          const float* const* H,
                           int numChannels,
                           int numSamples,
                           int sampleRate);

--- a/examples/include/panner.h
+++ b/examples/include/panner.h
@@ -143,7 +143,7 @@ void panner_initCodec(void* const hPan);
  */
 void panner_process(void* const hPan,
                     const float *const * inputs,
-                    float** const outputs,
+                    float* const* outputs,
                     int nInputs,
                     int nOutputs,
                     int nSamples);

--- a/examples/include/pitch_shifter.h
+++ b/examples/include/pitch_shifter.h
@@ -144,7 +144,7 @@ void pitch_shifter_initCodec(void* const hPS);
  */
 void pitch_shifter_process(void* const hPS,
                            const float *const * inputs,
-                           float** const outputs,
+                           float* const* const outputs,
                            int nInputs,
                            int nOutputs,
                            int nSamples);

--- a/examples/include/rotator.h
+++ b/examples/include/rotator.h
@@ -88,7 +88,7 @@ void rotator_init(void* const hRot,
  */
 void rotator_process(void* const hRot,
                      const float *const * inputs,
-                     float** const outputs,
+                     float* const* outputs,
                      int nInputs,
                      int nOutputs,
                      int nSamples);

--- a/examples/include/spreader.h
+++ b/examples/include/spreader.h
@@ -118,7 +118,7 @@ void spreader_initCodec(void* const hSpr);
  */
 void spreader_process(void* const hSpr,
                       const float *const * inputs,
-                      float** const outputs,
+                      float* const* outputs,
                       int nInputs,
                       int nOutputs,
                       int nSamples);

--- a/examples/include/tvconv.h
+++ b/examples/include/tvconv.h
@@ -70,8 +70,8 @@ void tvconv_init(void* const hTVCnv,
  * @param[in] nSamples  Number of samples in 'inputs'/'output' matrices (block size)
  */
 void tvconv_process(void* const hTVCnv,
-                    float** const inputs,
-                    float** const outputs,
+                    float* const* const inputs,
+                    float* const* const outputs,
                     int nInputs,
                     int nOutputs,
                     int nSamples);

--- a/examples/src/ambi_bin/ambi_bin.c
+++ b/examples/src/ambi_bin/ambi_bin.c
@@ -383,7 +383,7 @@ void ambi_bin_process
 (
     void        *  const hAmbi,
     const float *const * inputs,
-    float       ** const outputs,
+    float* const*  const outputs,
     int                  nInputs,
     int                  nOutputs,
     int                  nSamples

--- a/examples/src/ambi_dec/ambi_dec.c
+++ b/examples/src/ambi_dec/ambi_dec.c
@@ -147,7 +147,7 @@ void ambi_dec_destroy
         free(pars->hrtf_fb);
         free(pars->hrtf_fb_mag);
         free(pars->itds_s);
-	free(pars->sofa_filepath);
+    free(pars->sofa_filepath);
         free(pars->hrirs);
         free(pars->hrir_dirs_deg);
         free(pars->weights);
@@ -458,7 +458,7 @@ void ambi_dec_process
 (
     void        *  const hAmbi,
     const float *const * inputs,
-    float       ** const outputs,
+    float* const*  const outputs,
     int                  nInputs,
     int                  nOutputs,
     int                  nSamples

--- a/examples/src/ambi_drc/ambi_drc.c
+++ b/examples/src/ambi_drc/ambi_drc.c
@@ -136,7 +136,7 @@ void ambi_drc_process
 (
     void        *  const hAmbi,
     const float *const * inputs,
-    float       ** const outputs,
+    float* const*  const outputs,
     int                  nCh,
     int                  nSamples
 )                                         

--- a/examples/src/ambi_enc/ambi_enc.c
+++ b/examples/src/ambi_enc/ambi_enc.c
@@ -87,7 +87,7 @@ void ambi_enc_process
 (
     void        *  const hAmbi,
     const float *const * inputs,
-    float       ** const outputs,
+    float* const*  const outputs,
     int                  nInputs,
     int                  nOutputs,
     int                  nSamples

--- a/examples/src/ambi_roomsim/ambi_roomsim.c
+++ b/examples/src/ambi_roomsim/ambi_roomsim.c
@@ -105,7 +105,7 @@ void ambi_roomsim_process
 (
     void        *  const hAmbi,
     const float *const * inputs,
-    float       ** const outputs,
+    float* const*  const outputs,
     int                  nInputs,
     int                  nOutputs,
     int                  nSamples

--- a/examples/src/array2sh/array2sh.c
+++ b/examples/src/array2sh/array2sh.c
@@ -170,7 +170,7 @@ void array2sh_process
 (
     void        *  const hA2sh,
     const float *const * inputs,
-    float       ** const outputs,
+    float* const*  const outputs,
     int                  nInputs,
     int                  nOutputs,
     int                  nSamples

--- a/examples/src/beamformer/beamformer.c
+++ b/examples/src/beamformer/beamformer.c
@@ -95,7 +95,7 @@ void beamformer_process
 (
     void        *  const hBeam,
     const float *const * inputs,
-    float       ** const outputs,
+    float* const*  const outputs,
     int                  nInputs,
     int                  nOutputs,
     int                  nSamples

--- a/examples/src/binauraliser/binauraliser.c
+++ b/examples/src/binauraliser/binauraliser.c
@@ -192,7 +192,7 @@ void binauraliser_process
 (
     void        *  const hBin,
     const float *const * inputs,
-    float       ** const outputs,
+    float* const*  const outputs,
     int                  nInputs,
     int                  nOutputs,
     int                  nSamples

--- a/examples/src/binauraliser_nf/binauraliser_nf.c
+++ b/examples/src/binauraliser_nf/binauraliser_nf.c
@@ -225,7 +225,7 @@ void binauraliserNF_process /* FREQ DOMAIN version */
 (
     void        *  const hBin,
     const float *const * inputs,
-    float       ** const outputs,
+    float* const*  const outputs,
     int                  nInputs,
     int                  nOutputs,
     int                  nSamples

--- a/examples/src/decorrelator/decorrelator.c
+++ b/examples/src/decorrelator/decorrelator.c
@@ -161,7 +161,7 @@ void decorrelator_process
 (
     void        *  const hDecor,
     const float *const * inputs,
-    float       ** const outputs,
+    float* const*  const outputs,
     int                  nInputs,
     int                  nOutputs,
     int                  nSamples

--- a/examples/src/matrixconv/matrixconv.c
+++ b/examples/src/matrixconv/matrixconv.c
@@ -97,7 +97,7 @@ void matrixconv_process
 (
     void        *  const hMCnv,
     const float *const * inputs,
-    float       ** const outputs,
+    float* const*  const outputs,
     int                  nInputs,
     int                  nOutputs,
     int                  nSamples
@@ -205,7 +205,7 @@ void matrixconv_checkReInit(void* const hMCnv)
 void matrixconv_setFilters
 (
     void* const hMCnv,
-    const float** H,
+    const float* const* H,
     int numChannels,
     int numSamples,
     int sampleRate

--- a/examples/src/multiconv/multiconv.c
+++ b/examples/src/multiconv/multiconv.c
@@ -95,7 +95,7 @@ void multiconv_process
 (
     void        *  const hMCnv,
     const float *const * inputs,
-    float       ** const outputs,
+    float* const*  const outputs,
     int                  nInputs,
     int                  nOutputs,
     int                  nSamples
@@ -194,7 +194,7 @@ void multiconv_checkReInit(void* const hMCnv)
 void multiconv_setFilters
 (
     void* const hMCnv,
-    const float** H,
+    const float* const* H,
     int numChannels,
     int numSamples,
     int sampleRate

--- a/examples/src/panner/panner.c
+++ b/examples/src/panner/panner.c
@@ -174,7 +174,7 @@ void panner_process
 (
     void        *  const hPan,
     const float *const * inputs,
-    float       ** const outputs,
+    float* const*  const outputs,
     int                  nInputs,
     int                  nOutputs,
     int                  nSamples

--- a/examples/src/pitch_shifter/pitch_shifter.c
+++ b/examples/src/pitch_shifter/pitch_shifter.c
@@ -158,7 +158,7 @@ void pitch_shifter_process
 (
     void        *  const hPS,
     const float *const * inputs,
-    float       ** const outputs,
+    float* const*  const outputs,
     int                  nInputs,
     int                  nOutputs,
     int                  nSamples

--- a/examples/src/rotator/rotator.c
+++ b/examples/src/rotator/rotator.c
@@ -101,7 +101,7 @@ void rotator_process
 (
     void        *  const hRot,
     const float *const * inputs,
-    float       ** const outputs,
+    float* const*  const outputs,
     int                  nInputs,
     int                  nOutputs,
     int                  nSamples

--- a/examples/src/spreader/spreader.c
+++ b/examples/src/spreader/spreader.c
@@ -121,7 +121,7 @@ void spreader_destroy
             SAF_SLEEP(10);
         }
 
-	free(pData->sofa_filepath);
+    free(pData->sofa_filepath);
         
         /* free afSTFT and buffers */
         if(pData->hSTFT !=NULL)
@@ -341,7 +341,7 @@ void spreader_process
 (
     void        *  const hSpr,
     const float *const * inputs,
-    float       ** const outputs,
+    float* const*  const outputs,
     int                  nInputs,
     int                  nOutputs,
     int                  nSamples

--- a/examples/src/tvconv/tvconv.c
+++ b/examples/src/tvconv/tvconv.c
@@ -119,8 +119,8 @@ void tvconv_init
 void tvconv_process
 (
     void  *  const hTVCnv,
-    float ** const inputs,
-    float ** const outputs,
+    float* const* const inputs,
+    float* const* const outputs,
     int            nInputs,
     int            nOutputs,
     int            nSamples


### PR DESCRIPTION
## What is the goal of this PR?

fix type conversion issues when using functions with SPARTA, JUCE 7, under Linux with g++ 9.

## What are the changes implemented in this PR?

declarations of parameters for some functions.
