### PR TITLE
Use correct dimensions when clearing ambi_enc SH weights buffer

### DIFF
--- a/examples/src/ambi_enc/ambi_enc.c
+++ b/examples/src/ambi_enc/ambi_enc.c
@@ -77,8 +77,8 @@ void ambi_enc_init
         pData->interpolator_fadeIn[i-1]  = (float)i*1.0f/(float)AMBI_ENC_FRAME_SIZE;
         pData->interpolator_fadeOut[i-1] = 1.0f - pData->interpolator_fadeIn[i-1];
     }
-    memset(pData->prev_Y, 0, MAX_NUM_SH_SIGNALS*MAX_NUM_SH_SIGNALS*sizeof(float));
-    memset(pData->prev_inputFrameTD, 0, MAX_NUM_SH_SIGNALS*AMBI_ENC_FRAME_SIZE*sizeof(float));
+    memset(pData->prev_Y, 0, MAX_NUM_SH_SIGNALS*MAX_NUM_INPUTS*sizeof(float));
+    memset(pData->prev_inputFrameTD, 0, MAX_NUM_INPUTS*AMBI_ENC_FRAME_SIZE*sizeof(float));
     for(i=0; i<MAX_NUM_INPUTS; i++)
         pData->recalc_SH_FLAG[i] = 1;
 }


### PR DESCRIPTION
This fixes garbage output when MAX_NUM_CHANNELS is increased beyond 64

## What is the goal of this PR?

To fix a bug I noticed whereby the ambisonic encoder will output noise if the max channel count is increased beyond 64.  I have not created an issue for it since the change is minor.

## What are the changes implemented in this PR?

An array index in a memset() call has been changed from one that coincidentally had the correct value, to the one that was used when the array was declared.
