### PR TITLE
FIRCoeffs: fix normalized freq calc and f0 in unity gain factor

### DIFF
--- a/framework/modules/saf_utilities/saf_utility_filters.c
+++ b/framework/modules/saf_utilities/saf_utility_filters.c
@@ -1282,7 +1282,7 @@ void FIRCoeffs
     float_complex h_z_sum;
     
     h_len = order + 1;
-    ft1 = fc1/(fs*2.0f);
+    ft1 = fc1/fs;
     
     /* compute filter weights */
     if(order % 2 == 0){
@@ -1299,7 +1299,7 @@ void FIRCoeffs
                 break;
                 
             case FIR_FILTER_BPF:
-                ft2 = fc2/(fs*2.0f);
+                ft2 = fc2/fs;
                 for(i=0; i<h_len; i++){
                     h_filt[i] = i==order/2 ? 2.0f*(ft2-ft1) :
                         sinf(2.0f*SAF_PI*ft2*(float)(i-order/2)) / (SAF_PI*(float)(i-order/2)) - sinf(2.0f*SAF_PI*ft1*(float)(i-order/2)) / (SAF_PI*(float)(i-order/2));
@@ -1307,7 +1307,7 @@ void FIRCoeffs
                 break;
                 
             case FIR_FILTER_BSF:
-                ft2 = fc2/(fs*2.0f);
+                ft2 = fc2/fs;
                 for(i=0; i<h_len; i++){
                     h_filt[i] = i==order/2 ? 1.0f - 2.0f*(ft2-ft1) :
                         sinf(2.0f*SAF_PI*ft1*(float)(i-order/2)) / (SAF_PI*(float)(i-order/2)) - sinf(2.0f*SAF_PI*ft2*(float)(i-order/2)) / (SAF_PI*(float)(i-order/2));
@@ -1347,7 +1347,7 @@ void FIRCoeffs
                 break;
                 
             case FIR_FILTER_BPF:
-                f0 = (fc1/fs+fc2/fs)/2.0f;
+                f0 = fc1/fs + fc2/fs;
                 h_z_sum = cmplxf(0.0f, 0.0f);
                 for(i=0; i<h_len; i++)
                     h_z_sum = ccaddf(h_z_sum, crmulf(cexpf(cmplxf(0.0f, -2.0f*SAF_PI*(float)i*f0/2.0f)), h_filt[i]));


### PR DESCRIPTION
## What is the goal of this PR?

Previous normalized frequency calculation resulted in cuton/off frequencies that were shifted down one octave.

## What are the changes implemented in this PR?

Correct the filter coefficient calculation to give proper cuton/off frequencies.
It's now in parity with MATLAB's `fir1`.

NOTE:
This was tested using `FIRFilterbank`, which uses and LPF, HPF and BPF, so the stopband filter was not tested, but the corresponding normalized freq was updated there too.
I was testing with the `scalingFLAG = 1.0`, so it would be good to confirm whether this impacts the result when the scaling flag is `false`.

Depending on your reference for generating these sincs, you may prefer to equivalently change the sinc to use a sin argument in terms of `pi` rather than `2pi`, but a quick test showed the center sample calculation would also need to be changed, and how wasn't immediately obvious. So this is a minimal effective change.