### PR TITLE
Always Clear Dereferenced Pointers in `*_destroy` Functions

### DIFF
--- a/examples/src/ambi_dec/ambi_dec.c
+++ b/examples/src/ambi_dec/ambi_dec.c
@@ -162,6 +162,7 @@ void ambi_dec_destroy
         free(pData->progressBarText);
         free(pData);
         pData = NULL;
+        *phAmbi = NULL;
     }
 }
 

--- a/examples/src/ambi_drc/ambi_drc.c
+++ b/examples/src/ambi_drc/ambi_drc.c
@@ -98,6 +98,7 @@ void ambi_drc_destroy
 #endif
         free(pData);
         pData = NULL;
+        *phAmbi = NULL;
     }
 }
 

--- a/examples/src/ambi_enc/ambi_enc.c
+++ b/examples/src/ambi_enc/ambi_enc.c
@@ -60,6 +60,7 @@ void ambi_enc_destroy
     if (pData != NULL) {
         free(pData);
         pData = NULL;
+        *phAmbi = NULL;
     }
 }
 

--- a/examples/src/ambi_roomsim/ambi_roomsim.c
+++ b/examples/src/ambi_roomsim/ambi_roomsim.c
@@ -88,6 +88,7 @@ void ambi_roomsim_destroy
         free(pData->rec_sh_outsigs);
         free(pData);
         pData = NULL;
+        *phAmbi = NULL;
     }
 }
 

--- a/examples/src/array2sh/array2sh.c
+++ b/examples/src/array2sh/array2sh.c
@@ -126,6 +126,7 @@ void array2sh_destroy
         
         free(pData);
         pData = NULL;
+        *phM2sh = NULL;
     }
 }
 

--- a/examples/src/beamformer/beamformer.c
+++ b/examples/src/beamformer/beamformer.c
@@ -64,6 +64,7 @@ void beamformer_destroy
         
         free(pData);
         pData = NULL;
+        *phBeam = NULL;
     }
 }
 

--- a/examples/src/binauraliser/binauraliser.c
+++ b/examples/src/binauraliser/binauraliser.c
@@ -129,6 +129,7 @@ void binauraliser_destroy
          
         free(pData);
         pData = NULL;
+        *phBin = NULL;
     }
 }
 

--- a/examples/src/binauraliser_nf/binauraliser_nf.c
+++ b/examples/src/binauraliser_nf/binauraliser_nf.c
@@ -167,6 +167,7 @@ void binauraliserNF_destroy
         
         free(pData);
         pData = NULL;
+        *phBin = NULL;
     }
 }
 

--- a/examples/src/dirass/dirass.c
+++ b/examples/src/dirass/dirass.c
@@ -139,6 +139,7 @@ void dirass_destroy
         free(pData->progressBarText);
         free(pData);
         pData = NULL;
+        *phDir = NULL;
     }
 }
 

--- a/examples/src/matrixconv/matrixconv.c
+++ b/examples/src/matrixconv/matrixconv.c
@@ -70,6 +70,7 @@ void matrixconv_destroy
         saf_matrixConv_destroy(&(pData->hMatrixConv));
         free(pData);
         pData = NULL;
+        *phMCnv = NULL;
     }
 }
 

--- a/examples/src/multiconv/multiconv.c
+++ b/examples/src/multiconv/multiconv.c
@@ -68,6 +68,7 @@ void multiconv_destroy
         saf_multiConv_destroy(&(pData->hMultiConv));
         free(pData);
         pData = NULL;
+        *phMCnv = NULL;
     }
 }
 

--- a/examples/src/panner/panner.c
+++ b/examples/src/panner/panner.c
@@ -112,6 +112,7 @@ void panner_destroy
         
         free(pData);
         pData = NULL;
+        *phPan = NULL;
     }
 }
 

--- a/examples/src/pitch_shifter/pitch_shifter.c
+++ b/examples/src/pitch_shifter/pitch_shifter.c
@@ -77,6 +77,7 @@ void pitch_shifter_destroy
             smb_pitchShift_destroy(&(pData->hSmb));
         free(pData);
         pData = NULL;
+        *phPS = NULL;
     }
 }
 

--- a/examples/src/powermap/powermap.c
+++ b/examples/src/powermap/powermap.c
@@ -128,6 +128,7 @@ void powermap_destroy
         free(pData->progressBarText);
         free(pData);
         pData = NULL;
+        *phPm = NULL;
     }
 }
 

--- a/examples/src/sldoa/sldoa.c
+++ b/examples/src/sldoa/sldoa.c
@@ -133,6 +133,7 @@ void sldoa_destroy
         free(pData->progressBarText);
         free(pData);
         pData = NULL;
+        *phSld = NULL;
     }
 }
 

--- a/examples/src/spreader/spreader.c
+++ b/examples/src/spreader/spreader.c
@@ -168,6 +168,7 @@ void spreader_destroy
          
         free(pData);
         pData = NULL;
+        *phSpr = NULL;
     }
 }
 

--- a/examples/src/tvconv/tvconv.c
+++ b/examples/src/tvconv/tvconv.c
@@ -94,6 +94,7 @@ void tvconv_destroy
         saf_TVConv_destroy(&(pData->hTVConv));
         free(pData);
         pData = NULL;
+        *phTVCnv = NULL;
     }
 }
 

--- a/framework/modules/saf_cdf4sap/saf_cdf4sap.c
+++ b/framework/modules/saf_cdf4sap/saf_cdf4sap.c
@@ -226,6 +226,7 @@ void cdf4sap_destroy
         free(h->G_M);
         free(h);
         h = NULL;
+        *phCdf = NULL;
     }
 }
 
@@ -264,6 +265,7 @@ void cdf4sap_cmplx_destroy
         free(h->G_M);
         free(h);
         h = NULL;
+        *phCdf = NULL;
     }
 }
 

--- a/framework/modules/saf_tracker/saf_tracker.c
+++ b/framework/modules/saf_tracker/saf_tracker.c
@@ -147,6 +147,7 @@ void tracker3d_destroy
 
         free(pData);
         pData = NULL;
+        *phT3d = NULL;
     }
 }
 

--- a/framework/modules/saf_utilities/saf_utility_fft.c
+++ b/framework/modules/saf_utilities/saf_utility_fft.c
@@ -661,7 +661,8 @@ void saf_rfft_destroy
         }
 
         free(h);
-        h=NULL;
+        h = NULL;
+        *phFFT = NULL;
     }
 }
 
@@ -888,7 +889,8 @@ void saf_fft_destroy
         }
 
         free(h);
-        h=NULL;
+        h = NULL;
+        *phFFT = NULL;
     }
 }
 

--- a/framework/modules/saf_utilities/saf_utility_matrixConv.c
+++ b/framework/modules/saf_utilities/saf_utility_matrixConv.c
@@ -156,7 +156,8 @@ void saf_matrixConv_destroy
             free(h->Hpart_f);
         }
         free(h);
-        h=NULL;
+        h = NULL;
+        *phMC = NULL;
     }
 }
 
@@ -363,7 +364,8 @@ void saf_multiConv_destroy
             free(h->Hpart_f);
         }
         free(h);
-        h=NULL;
+        h = NULL;
+        *phMC = NULL;
     }
 }
 
@@ -568,7 +570,8 @@ void saf_TVConv_destroy
         free(h->Hpart_f);
         }
         free(h);
-        h=NULL;
+        h = NULL;
+        *phTVC = NULL;
 }
 
 void saf_TVConv_apply

--- a/framework/modules/saf_utilities/saf_utility_pitch.c
+++ b/framework/modules/saf_utilities/saf_utility_pitch.c
@@ -192,7 +192,8 @@ void smb_pitchShift_destroy
         free(h->gSynFreq);
         free(h->gSynMagn);
         free(h);
-        h=NULL;
+        h = NULL;
+        *hSmb = NULL;
     }
 }
 


### PR DESCRIPTION
## What is the goal of this PR?

Ensure that references to a structure are `NULL`ed when passed to a `*_destroy` function.

## What are the changes implemented in this PR?

When a function takes a double pointer to a structure with the intention of destroying it, it is expected to set the direct pointer to the structure to `NULL`. For example, I would expect the following test to pass for any particular structure:

```c
void *some_structure;
my_structure_create(&some_structure);
my_structure_destroy(&some_structure);

assert(some_structure == NULL);        // this should pass because my_structure_destroy
                                       // set some_structure to NULL
```

Many of the structures in SAF do this, but not all. This PR attempts to implement this for all structures.