### PR TITLE
Add missing handling of LOUDSPEAKER_ARRAY_PRESET_STEREO in ambi_dec

### DIFF
--- a/examples/src/ambi_dec/ambi_dec_internal.c
+++ b/examples/src/ambi_dec/ambi_dec_internal.c
@@ -131,6 +131,12 @@ void loadLoudspeakerArrayPreset
             /* fall through */
         case LOUDSPEAKER_ARRAY_PRESET_DEFAULT:
             /* fall through */
+        case LOUDSPEAKER_ARRAY_PRESET_STEREO:
+            nCH = 2;
+            for(ch=0; ch<nCH; ch++)
+                for(i=0; i<2; i++)
+                    dirs_deg[ch][i] = __stereo_dirs_deg[ch][i];
+            break;
         case LOUDSPEAKER_ARRAY_PRESET_5PX:
             nCH = 5;
             for(ch=0; ch<nCH; ch++)


### PR DESCRIPTION
Please replace every line in curly brackets ( { like this } ) with an appropriate description, and remove this line.

## What is the goal of this PR?

Handle stereo loudspeaker preset properly.

## What are the changes implemented in this PR?

Add handling of the stereo loudspeaker preset in `loadLoudspeakerArrayPreset` instead of falling back to default 5PX

