### PR TITLE
Fix memory leak in qmf & decor

### DIFF
--- a/framework/modules/saf_utilities/saf_utility_decor.c
+++ b/framework/modules/saf_utilities/saf_utility_decor.c
@@ -311,6 +311,8 @@ void latticeDecorrelator_destroy
         }
         free(h->lttc_apf);
 
+        free(h->in_energy);
+        free(h->decor_energy);
         free(h->delayBuffers);
         free(h->wIdx);
         free(h->rIdx);

--- a/framework/modules/saf_utilities/saf_utility_qmf.c
+++ b/framework/modules/saf_utilities/saf_utility_qmf.c
@@ -288,8 +288,10 @@ void qmf_destroy
         /* For run-time */
         for(i=0; i<h->nCHin; i++)
             free(h->buffer_ana[i]);
+        free(h->buffer_ana);
         for(i=0; i<h->nCHout; i++)
             free(h->buffer_syn[i]);
+        free(h->buffer_syn);
         free(h->buffer_win);
         free(h->win_sum);
         free(h->win_sum_cmplx_dummy);


### PR DESCRIPTION
## What is the goal of this PR?

- In the `latticeDecor_data` struct, the `in_energy` and `decor_energy` members are not freed during the destruction process.
- For the `qmf_data` struct, its `buffer_ana` and `buffer_syn` members are 2D arrays, but the outermost pointers of these arrays are not freed during destruction.

## What are the changes implemented in this PR?

Corresponding free() operations have been added to the destruction function to address the above issues.
