### PR TITLE
Fix compiler exception in Visual Studio

### DIFF
--- a/framework/modules/saf_utilities/saf_utility_filters.c
+++ b/framework/modules/saf_utilities/saf_utility_filters.c
@@ -66,7 +66,7 @@ static void applyWindowingFunction
             
         case WINDOWING_FUNCTION_BARTLETT:
             for(i=0; i<winlength; i++)
-                x[i] *= 1.0f - 2.0f * fabsf((float)i-((float)N/2.0f))/(float)N;
+                x[i] *= 1.0f - 2.0f * (fabsf((float)i-((float)N/2.0f))/(float)N);
             break;
             
         case WINDOWING_FUNCTION_BLACKMAN:


### PR DESCRIPTION
## What is the goal of this PR?

The Visual Studio compiler fails with an exception when running with maximum optimization (default for release builds). This is a regression in the compiler, but it is not likely that it will be fixed anytime soon. Currently this is a show-stopper for building SAF with Visual Studio on Windows.

## What are the changes implemented in this PR?

By simply adding a couple of parentheses without any change in the logic, the compiler is happy.
